### PR TITLE
Page title tags

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,17 +8,20 @@ interface LayoutProps {
   children: ReactNode;
   head?: ReactNode;
   navigation?: ReactNode;
-  title?: string;
+  title: string;
+  pageHasErrors?: boolean;
 }
 
 interface BeaconRegistrationHeadProps {
-  title?: string;
+  title: string;
+  pageHasErrors?: boolean;
 }
 
 export const Layout: FunctionComponent<LayoutProps> = ({
   children,
-  title = "",
-  head = <BeaconRegistrationHead title={title} />,
+  title,
+  pageHasErrors = false,
+  head = <BeaconRegistrationHead title={title} pageHasErrors={pageHasErrors} />,
   navigation = null,
 }: LayoutProps): JSX.Element => (
   <>
@@ -52,13 +55,13 @@ export const Layout: FunctionComponent<LayoutProps> = ({
 
 const BeaconRegistrationHead: FunctionComponent<BeaconRegistrationHeadProps> = ({
   title,
+  pageHasErrors = false,
 }: BeaconRegistrationHeadProps) => {
-  const headTitle = title
-    ? `${title} - Beacon Registration Service`
-    : "Beacon Registration Service - Register a new 406 MHz distress beacon";
+  const headTitle = pageHasErrors ? `Error: ${title}` : `${title}`;
+
   return (
     <Head>
-      <title>{headTitle}</title>
+      <title>{`${headTitle} - Beacon Registration Service - GOV.UK`}</title>
     </Head>
   );
 };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,11 +8,17 @@ interface LayoutProps {
   children: ReactNode;
   head?: ReactNode;
   navigation?: ReactNode;
+  title?: string;
+}
+
+interface BeaconRegistrationHeadProps {
+  title?: string;
 }
 
 export const Layout: FunctionComponent<LayoutProps> = ({
   children,
-  head = <BeaconRegistrationHead />,
+  title = "",
+  head = <BeaconRegistrationHead title={title} />,
   navigation = null,
 }: LayoutProps): JSX.Element => (
   <>
@@ -22,7 +28,7 @@ export const Layout: FunctionComponent<LayoutProps> = ({
     </a>
     <Header
       serviceName={"Maritime and Coastguard Agency: Register a beacon"}
-      homeLink={"#"}
+      homeLink={"/"}
     />
     <PhaseBanner phase="BETA">
       This is a new service – your{" "}
@@ -44,10 +50,15 @@ export const Layout: FunctionComponent<LayoutProps> = ({
   </>
 );
 
-const BeaconRegistrationHead: FunctionComponent = () => (
-  <Head>
-    <title>
-      Beacon Registration Service - Register a new 406 MHz distress beacon
-    </title>
-  </Head>
-);
+const BeaconRegistrationHead: FunctionComponent<BeaconRegistrationHeadProps> = ({
+  title,
+}: BeaconRegistrationHeadProps) => {
+  const headTitle = title
+    ? `${title} - Beacon Registration Service`
+    : "Beacon Registration Service - Register a new 406 MHz distress beacon";
+  return (
+    <Head>
+      <title>{headTitle}</title>
+    </Head>
+  );
+};

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -57,7 +57,7 @@ const BeaconRegistrationHead: FunctionComponent<BeaconRegistrationHeadProps> = (
   title,
   pageHasErrors = false,
 }: BeaconRegistrationHeadProps) => {
-  const headTitle = pageHasErrors ? `Error: ${title}` : `${title}`;
+  const headTitle = pageHasErrors ? `Error: ${title}` : title;
 
   return (
     <Head>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,18 +9,18 @@ interface LayoutProps {
   head?: ReactNode;
   navigation?: ReactNode;
   title: string;
-  pageHasErrors?: boolean;
+  pageHasErrors: boolean;
 }
 
 interface BeaconRegistrationHeadProps {
   title: string;
-  pageHasErrors?: boolean;
+  pageHasErrors: boolean;
 }
 
 export const Layout: FunctionComponent<LayoutProps> = ({
   children,
   title,
-  pageHasErrors = false,
+  pageHasErrors,
   head = <BeaconRegistrationHead title={title} pageHasErrors={pageHasErrors} />,
   navigation = null,
 }: LayoutProps): JSX.Element => (
@@ -55,7 +55,7 @@ export const Layout: FunctionComponent<LayoutProps> = ({
 
 const BeaconRegistrationHead: FunctionComponent<BeaconRegistrationHeadProps> = ({
   title,
-  pageHasErrors = false,
+  pageHasErrors,
 }: BeaconRegistrationHeadProps) => {
   const headTitle = pageHasErrors ? `Error: ${title}` : title;
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,12 +5,14 @@ import { BeaconRegistryContactInfo } from "../components/Mca";
 import { GovUKBody } from "../components/Typography";
 
 const FourOhFour: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "Page not found";
+
   return (
-    <Layout>
+    <Layout title={pageHeading}>
       <Grid
         mainContent={
           <>
-            <h1 className="govuk-heading-l">Page not found</h1>
+            <h1 className="govuk-heading-l">{pageHeading}</h1>
             <GovUKBody>
               If you typed the web address, check it is correct.
             </GovUKBody>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -8,7 +8,7 @@ const FourOhFour: FunctionComponent = (): JSX.Element => {
   const pageHeading = "Page not found";
 
   return (
-    <Layout title={pageHeading}>
+    <Layout title={pageHeading} pageHasErrors={false}>
       <Grid
         mainContent={
           <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,11 @@ const ServiceStartPage: FunctionComponent = (): JSX.Element => {
 
   return (
     <>
-      <Layout navigation={<Breadcrumbs />} title={pageHeading}>
+      <Layout
+        navigation={<Breadcrumbs />}
+        title={pageHeading}
+        pageHasErrors={false}
+      >
         <Grid
           mainContent={
             <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,26 +17,28 @@ import {
 import { WarningText } from "../components/WarningText";
 import { setFormSubmissionCookie } from "../lib/middleware";
 
-const ServiceStartPage: FunctionComponent = (): JSX.Element => (
-  <>
-    <Layout navigation={<Breadcrumbs />}>
-      <Grid
-        mainContent={
-          <>
-            <PageHeading>
-              Register a single UK 406MHz Personal Locator Beacon (PLB) for
-              maritime use
-            </PageHeading>
-            <AboutTheService />
-            <OtherWaysToAccessTheService />
-            <DataProtection />
-          </>
-        }
-        aside={<RelatedContent />}
-      />
-    </Layout>
-  </>
-);
+const ServiceStartPage: FunctionComponent = (): JSX.Element => {
+  const pageHeading =
+    "Register a single UK 406MHz Personal Locator Beacon (PLB) for maritime use";
+
+  return (
+    <>
+      <Layout navigation={<Breadcrumbs />} title={pageHeading}>
+        <Grid
+          mainContent={
+            <>
+              <PageHeading>{pageHeading}</PageHeading>
+              <AboutTheService />
+              <OtherWaysToAccessTheService />
+              <DataProtection />
+            </>
+          }
+          aside={<RelatedContent />}
+        />
+      </Layout>
+    </>
+  );
+};
 
 const Breadcrumbs: FunctionComponent = (): JSX.Element => (
   <BreadcrumbList>

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -15,19 +15,20 @@ import { TextareaCharacterCount } from "../../components/Textarea";
 import { withCookieRedirect } from "../../lib/middleware";
 
 const AboutTheVessel: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "About the pleasure vessel";
+
   return (
     <>
       <Layout
         navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
+        title={pageHeading}
       >
         <Grid
           mainContent={
             <>
               <Form action="/register-a-beacon/about-the-vessel">
                 <FormFieldset>
-                  <FormLegendPageHeading>
-                    About the pleasure vessel
-                  </FormLegendPageHeading>
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
 
                   <MaxCapacityInput />
 

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -17,11 +17,14 @@ import { withCookieRedirect } from "../../lib/middleware";
 const AboutTheVessel: FunctionComponent = (): JSX.Element => {
   const pageHeading = "About the pleasure vessel";
 
+  // TODO: Use form validation to set this
+  const pageHasErrors = false;
   return (
     <>
       <Layout
         navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
         title={pageHeading}
+        pageHasErrors={pageHasErrors}
       >
         <Grid
           mainContent={

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -12,7 +12,7 @@ const ApplicationCompletePage: FunctionComponent = (): JSX.Element => {
 
   return (
     <>
-      <Layout title={pageHeading}>
+      <Layout title={pageHeading} pageHasErrors={false}>
         <Grid
           mainContent={
             <>

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -7,33 +7,37 @@ import { GovUKBody } from "../../components/Typography";
 import { WarningText } from "../../components/WarningText";
 import { withCookieRedirect } from "../../lib/middleware";
 
-const ApplicationCompletePage: FunctionComponent = (): JSX.Element => (
-  <>
-    <Layout>
-      <Grid
-        mainContent={
-          <>
-            <Panel title="Application Complete">
-              We have sent you a confirmation email.
-            </Panel>
-            <ApplicationCompleteWhatNext />
-            <WarningText>
-              <GovUKBody className="govuk-!-font-weight-bold">
-                You can still use your beacon. Search and Rescue will be able to
-                identify and locate you.
-              </GovUKBody>
-              <GovUKBody className="govuk-!-font-weight-bold">
-                Remember your beacon should only be used in an emergency. If
-                needed, you can also contact HM Coastguard 24/7 on Tel: 020 381
-                72630.
-              </GovUKBody>
-            </WarningText>
-          </>
-        }
-      />
-    </Layout>
-  </>
-);
+const ApplicationCompletePage: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "Application Complete";
+
+  return (
+    <>
+      <Layout title={pageHeading}>
+        <Grid
+          mainContent={
+            <>
+              <Panel title={pageHeading}>
+                We have sent you a confirmation email.
+              </Panel>
+              <ApplicationCompleteWhatNext />
+              <WarningText>
+                <GovUKBody className="govuk-!-font-weight-bold">
+                  You can still use your beacon. Search and Rescue will be able
+                  to identify and locate you.
+                </GovUKBody>
+                <GovUKBody className="govuk-!-font-weight-bold">
+                  Remember your beacon should only be used in an emergency. If
+                  needed, you can also contact HM Coastguard 24/7 on Tel: 020
+                  381 72630.
+                </GovUKBody>
+              </WarningText>
+            </>
+          }
+        />
+      </Layout>
+    </>
+  );
+};
 
 const ApplicationCompleteWhatNext: FunctionComponent = (): JSX.Element => (
   <>

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -26,10 +26,14 @@ import { withCookieRedirect } from "../../lib/middleware";
 const BeaconInformationPage: FunctionComponent = (): JSX.Element => {
   const pageHeading = "Beacon information";
 
+  // TODO: Use form validation to set this
+  const pageHasErrors = false;
+
   return (
     <Layout
       navigation={<BackButton href="/register-a-beacon/check-beacon-details" />}
       title={pageHeading}
+      pageHasErrors={pageHasErrors}
     >
       <Grid
         mainContent={

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -23,20 +23,20 @@ import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { withCookieRedirect } from "../../lib/middleware";
 
-const BeaconInformationPage: FunctionComponent = (): JSX.Element => (
-  <>
+const BeaconInformationPage: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "Beacon information";
+
+  return (
     <Layout
       navigation={<BackButton href="/register-a-beacon/check-beacon-details" />}
+      title={pageHeading}
     >
       <Grid
         mainContent={
           <>
-            {/*TODO: Update link to next step in service flow*/}
             <Form action="/register-a-beacon/beacon-information">
               <FormFieldset>
-                <FormLegendPageHeading>
-                  Beacon information
-                </FormLegendPageHeading>
+                <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
                 <InsetText>
                   Further information about your beacon is useful for Search &
                   Rescue. Provide as much information you can find.
@@ -57,8 +57,8 @@ const BeaconInformationPage: FunctionComponent = (): JSX.Element => (
         }
       />
     </Layout>
-  </>
-);
+  );
+};
 
 const BeaconManufacturerSerialNumberInput: FunctionComponent = (): JSX.Element => (
   <FormGroup>

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -45,9 +45,15 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
 
   const pageHeading = "Check beacon details";
 
+  const pageHasErrors = needsValidation && FormValidator.hasErrors(formData);
+
   return (
     <>
-      <Layout navigation={<BackButton href="/" />} title={pageHeading}>
+      <Layout
+        navigation={<BackButton href="/" />}
+        title={pageHeading}
+        pageHasErrors={pageHasErrors}
+      >
         <Grid
           mainContent={
             <>

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -43,18 +43,18 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
 
   const { manufacturer, model, hexId } = FormValidator.validate(formData);
 
+  const pageHeading = "Check beacon details";
+
   return (
     <>
-      <Layout navigation={<BackButton href="/" />}>
+      <Layout navigation={<BackButton href="/" />} title={pageHeading}>
         <Grid
           mainContent={
             <>
               {needsValidation && <FormErrorSummary errors={errors} />}
               <Form action="/register-a-beacon/check-beacon-details">
                 <FormFieldset>
-                  <FormLegendPageHeading>
-                    Check beacon details
-                  </FormLegendPageHeading>
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
                   <InsetText>
                     The details of your beacon must be checked to ensure they
                     have a UK encoding and if they are already registered with

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -19,19 +19,34 @@ interface BeaconDetailsProps {
   hexId: string;
 }
 
+interface BeaconDetailsSummaryProps extends BeaconDetailsProps {
+  heading: string;
+}
+
 const CheckBeaconSummaryPage: FunctionComponent<BeaconDetailsProps> = (
   props
-): JSX.Element => (
-  <>
-    <Layout
-      navigation={<BackButton href="/register-a-beacon/check-beacon-details" />}
-    >
-      <Grid mainContent={<BeaconNotRegisteredView {...props} />} />
-    </Layout>
-  </>
-);
+): JSX.Element => {
+  const pageHeading = "Beacon details checked";
 
-const BeaconNotRegisteredView: FunctionComponent<BeaconDetailsProps> = (
+  return (
+    <>
+      <Layout
+        navigation={
+          <BackButton href="/register-a-beacon/check-beacon-details" />
+        }
+        title={pageHeading}
+      >
+        <Grid
+          mainContent={
+            <BeaconNotRegisteredView {...props} heading={pageHeading} />
+          }
+        />
+      </Layout>
+    </>
+  );
+};
+
+const BeaconNotRegisteredView: FunctionComponent<BeaconDetailsSummaryProps> = (
   props
 ): JSX.Element => {
   return (
@@ -56,13 +71,14 @@ const BeaconNotRegisteredView: FunctionComponent<BeaconDetailsProps> = (
   );
 };
 
-const BeaconSummary: FunctionComponent<BeaconDetailsProps> = ({
+const BeaconSummary: FunctionComponent<BeaconDetailsSummaryProps> = ({
   manufacturer,
   model,
   hexId,
-}: BeaconDetailsProps): JSX.Element => (
+  heading,
+}: BeaconDetailsSummaryProps): JSX.Element => (
   <>
-    <h1 className="govuk-heading-l">Check beacon summary</h1>
+    <h1 className="govuk-heading-l">{heading}</h1>
     <SummaryList>
       <SummaryListItem
         labelText="Beacon manufacturer"

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -36,6 +36,7 @@ const CheckBeaconSummaryPage: FunctionComponent<BeaconDetailsProps> = (
           <BackButton href="/register-a-beacon/check-beacon-details" />
         }
         title={pageHeading}
+        pageHasErrors={false}
       >
         <Grid
           mainContent={

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -6,6 +6,7 @@ import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { NotificationBannerSuccess } from "../../components/NotificationBanner";
 import { SummaryList, SummaryListItem } from "../../components/SummaryList";
+import { PageHeading } from "../../components/Typography";
 import { BeaconCacheEntry } from "../../lib/formCache";
 import {
   getCache,
@@ -78,7 +79,7 @@ const BeaconSummary: FunctionComponent<BeaconDetailsSummaryProps> = ({
   heading,
 }: BeaconDetailsSummaryProps): JSX.Element => (
   <>
-    <h1 className="govuk-heading-l">{heading}</h1>
+    <PageHeading>{heading}</PageHeading>
     <SummaryList>
       <SummaryListItem
         labelText="Beacon manufacturer"

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -14,26 +14,31 @@ interface CheckYourAnswersProps {
 
 const CheckYourAnswersPage: FunctionComponent<CheckYourAnswersProps> = ({
   beacon,
-}: CheckYourAnswersProps): JSX.Element => (
-  <>
-    <Layout
-      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
-    >
-      <Grid
-        mainContent={
-          <>
-            <PageHeading>
-              Check your answers before sending in your registration
-            </PageHeading>
-            <BeaconInformation {...beacon} />
-            <SendYourApplication />
-            <Button buttonText="Accept and send" />
-          </>
-        }
-      />
-    </Layout>
-  </>
-);
+}: CheckYourAnswersProps): JSX.Element => {
+  const pageHeading = "Check your answers before sending in your registration";
+
+  return (
+    <>
+      <Layout
+        navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+        title={pageHeading}
+      >
+        <Grid
+          mainContent={
+            <>
+              <PageHeading>
+                Check your answers before sending in your registration
+              </PageHeading>
+              <BeaconInformation {...beacon} />
+              <SendYourApplication />
+              <Button buttonText="Accept and send" />
+            </>
+          }
+        />
+      </Layout>
+    </>
+  );
+};
 
 const BeaconInformation: FunctionComponent<Beacon> = ({
   manufacturer,

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -22,6 +22,7 @@ const CheckYourAnswersPage: FunctionComponent<CheckYourAnswersProps> = ({
       <Layout
         navigation={<BackButton href="/register-a-beacon/beacon-information" />}
         title={pageHeading}
+        pageHasErrors={false}
       >
         <Grid
           mainContent={

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -26,9 +26,7 @@ const CheckYourAnswersPage: FunctionComponent<CheckYourAnswersProps> = ({
         <Grid
           mainContent={
             <>
-              <PageHeading>
-                Check your answers before sending in your registration
-              </PageHeading>
+              <PageHeading>{pageHeading}</PageHeading>
               <BeaconInformation {...beacon} />
               <SendYourApplication />
               <Button buttonText="Accept and send" />

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -35,12 +35,15 @@ const MoreVesselDetails: FunctionComponent<MoreVesselDetailsProps> = ({
 
   const { moreVesselDetails } = FormValidator.validate(formData);
 
+  const pageHeading = "Tell us more about the vessel";
+
   return (
     <>
       <Layout
         navigation={
           <BackButton href="/register-a-beacon/vessel-communication-details" />
         }
+        title={pageHeading}
       >
         <Grid
           mainContent={
@@ -48,9 +51,7 @@ const MoreVesselDetails: FunctionComponent<MoreVesselDetailsProps> = ({
               {needsValidation && <FormErrorSummary errors={errors} />}
               <Form action="/register-a-beacon/more-vessel-details">
                 <FormFieldset>
-                  <FormLegendPageHeading>
-                    Tell us more about the vessel
-                  </FormLegendPageHeading>
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
 
                   <MoreVesselDetailsTextArea
                     value={formData.moreVesselDetails}

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -37,6 +37,8 @@ const MoreVesselDetails: FunctionComponent<MoreVesselDetailsProps> = ({
 
   const pageHeading = "Tell us more about the vessel";
 
+  const pageHasErrors = needsValidation && FormValidator.hasErrors(formData);
+
   return (
     <>
       <Layout
@@ -44,6 +46,7 @@ const MoreVesselDetails: FunctionComponent<MoreVesselDetailsProps> = ({
           <BackButton href="/register-a-beacon/vessel-communication-details" />
         }
         title={pageHeading}
+        pageHasErrors={pageHasErrors}
       >
         <Grid
           mainContent={

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -19,29 +19,38 @@ import {
 import { withCookieRedirect } from "../../lib/middleware";
 import { MaritimePleasureVessel } from "../../lib/types";
 
-const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => (
-  <Layout
-    navigation={<BackButton href="/register-a-beacon/beacon-information" />}
-  >
-    <Grid
-      mainContent={
-        <>
-          <BeaconUseForm />
+interface BeaconUseFormProps {
+  heading: string;
+}
 
-          <IfYouNeedHelp />
-        </>
-      }
-    />
-  </Layout>
-);
+const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => {
+  const pageHeading =
+    "What type of maritime pleasure vessel will you mostly use this beacon on?";
 
-const BeaconUseForm: FunctionComponent = (): JSX.Element => (
+  return (
+    <Layout
+      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+      title={pageHeading}
+    >
+      <Grid
+        mainContent={
+          <>
+            <BeaconUseForm heading={pageHeading} />
+
+            <IfYouNeedHelp />
+          </>
+        }
+      />
+    </Layout>
+  );
+};
+
+const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
+  heading,
+}: BeaconUseFormProps) => (
   <Form action="/register-a-beacon/primary-beacon-use">
     <FormFieldset>
-      <FormLegendPageHeading>
-        What type of maritime pleasure vessel will you mostly use this beacon
-        on?
-      </FormLegendPageHeading>
+      <FormLegendPageHeading>{heading}</FormLegendPageHeading>
     </FormFieldset>
     <RadioListConditional>
       <RadioListItemHint

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -27,10 +27,14 @@ const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => {
   const pageHeading =
     "What type of maritime pleasure vessel will you mostly use this beacon on?";
 
+  // TODO: Use form validation to set this
+  const pageHasErrors = false;
+
   return (
     <Layout
       navigation={<BackButton href="/register-a-beacon/beacon-information" />}
       title={pageHeading}
+      pageHasErrors={pageHasErrors}
     >
       <Grid
         mainContent={

--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -18,27 +18,40 @@ import {
   PageHeading,
 } from "../../components/Typography";
 
-const VesselCommunications: FunctionComponent = (): JSX.Element => (
-  <Layout
-    navigation={<BackButton href="/register-a-beacon/about-the-vessel" />}
-  >
-    <Grid
-      mainContent={
-        <>
-          <PageHeadingInfo />
-          <VesselCommunicationsForm />
-          <IfYouNeedHelp />
-        </>
-      }
-    ></Grid>
-  </Layout>
-);
+interface PageHeadingInfoProps {
+  heading: string;
+}
 
-const PageHeadingInfo: FunctionComponent = () => (
+const VesselCommunications: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "Check beacon details";
+
+  // TODO: Use form validation to set this
+  const pageHasErrors = false;
+
+  return (
+    <Layout
+      navigation={<BackButton href="/register-a-beacon/about-the-vessel" />}
+      title={pageHeading}
+      pageHasErrors={pageHasErrors}
+    >
+      <Grid
+        mainContent={
+          <>
+            <PageHeadingInfo heading={pageHeading} />
+            <VesselCommunicationsForm />
+            <IfYouNeedHelp />
+          </>
+        }
+      ></Grid>
+    </Layout>
+  );
+};
+
+const PageHeadingInfo: FunctionComponent<PageHeadingInfoProps> = ({
+  heading,
+}: PageHeadingInfoProps) => (
   <>
-    <PageHeading>
-      What types of communications are on board the vessel?
-    </PageHeading>
+    <PageHeading>{heading}</PageHeading>
 
     <GovUKBody>
       Details about the onboard communications will be critical for Search and


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We currently have a hardcoded title for all pages:

`Beacon Registration Service - Register a new 406 MHz distress beacon` 

And although there doesn't seem to be much guidance on how to do titles on the [GOV.UK Design System website](https://design-system.service.gov.uk/), [this github issue](https://github.com/alphagov/govuk-design-system-backlog/issues/157) led to some useful links mainly:
- [GOV.UK service manual guidance](https://www.gov.uk/service-manual/design/writing-for-user-interfaces#style)
- [HMRC Frontend guidance](http://hmrc.github.io/assets-frontend/components/page-title/index.html)

They both suggest that the **title should be unique for each page** and should follow this pattern:

`{Same text as the page's <h1>} - {Section name (if service has multiple sections)} - {Service name} - GOV.UK`

Also, if a page has an error, the title should start with `Error: ` so that a user knows there's an issue as soon as possible (especially important for screen readers!)

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- If there isn't an error on the page, the `<title>` is:
`{Unique text matching page's <h1>} - Beacon Registration Service - GOV.UK`

- If there is an error, it will be:
`Error: {Unique text matching page's <h1>} - Beacon Registration Service - GOV.UK`

-  Added two new props to `Layout` component: `title` and `pageHasErrors`:
   - `title` - a required prop, as every page needs a unique title
   - `pageHasErrors` - ~~optional and defaults to `false`, as not all pages will have errors (e.g `index` and `404`)~~ a required prop
      - This will hook into the awesome Form Validation work like [here](https://github.com/mcagov/beacons-webapp/blob/e9872d6696e9f3faaf7604b2b0f04781fe295f07/src/pages/register-a-beacon/check-beacon-details.tsx#L55)

- Made the Service Name link take you to the Service Start Page in the `Layout` component

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Not sure if this is the nicest/neatest was of doing this so please shout if something looks odd!
- Would it be better to make `pageHasErrors` a required prop, just so it isn't forgotten about?
  -   But would that just be annoying and unnecessary instead of helpful?
  - [Zack's comment](https://github.com/mcagov/beacons-webapp/pull/94#issuecomment-784094990) makes sense, so I've made this field required! ✨ 