### PR TITLE
Feature/primary beacon use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7405,11 +7405,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "optional": true
     },
-    "mock-req": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/mock-req/-/mock-req-0.2.0.tgz",
-      "integrity": "sha1-dJRGgE0sAGFpNC7nvmu6HP/VNMI="
-    },
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7448,6 +7448,11 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "optional": true
     },
+    "mock-req": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mock-req/-/mock-req-0.2.0.tgz",
+      "integrity": "sha1-dJRGgE0sAGFpNC7nvmu6HP/VNMI="
+    },
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "cookie": "^0.4.1",
     "govuk-frontend": "^3.11.0",
+    "mock-req": "^0.2.0",
     "next": "10.0.7",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/src/components/ErrorSummary.tsx
+++ b/src/components/ErrorSummary.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, ReactNode } from "react";
 import { IFormError } from "../lib/formValidator";
 
 interface FormErrorSummaryProps {
+  needsValidation: boolean;
   errors: IFormError[];
 }
 
@@ -23,10 +24,11 @@ interface ErrorSummaryProps {
 }
 
 export const FormErrorSummary: FunctionComponent<FormErrorSummaryProps> = ({
+  needsValidation,
   errors,
 }: FormErrorSummaryProps) => (
   <>
-    {errors && errors.length > 0 && (
+    {needsValidation && errors && errors.length > 0 && (
       <ErrorSummary>
         {errors.map((field) =>
           field.errorMessages.map((errorMessage, index) => (

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -25,7 +25,7 @@ interface RadioListItemHintProps {
   value: string;
   children: ReactNode;
   hintText: string;
-  inputHtmlAttributes?: Record<string, string>;
+  inputHtmlAttributes?: Record<string, string | boolean>;
 }
 
 interface RadioListItemConditionalProps {

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -1,3 +1,5 @@
+import { MaritimePleasureVessel } from "./types";
+
 export interface IFieldValidator {
   validate(value: string): IFieldValidationResponse;
 }
@@ -89,9 +91,31 @@ export class MoreVesselDetailsValidator extends FieldValidator {
   }
 }
 
+export class MaritimePleasureVesselUseValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Maritime pleasure use is a required field",
+        predicateFn: (value) => value.length === 0,
+      },
+      {
+        errorMessage:
+          "Value is not a recognised type of maritime pleasure vessel",
+        predicateFn: (value) =>
+          value.length !== 0 &&
+          !Object.values(MaritimePleasureVessel).includes(
+            value as MaritimePleasureVessel
+          ),
+      },
+    ];
+  }
+}
+
 export const fieldValidatorLookup = {
   manufacturer: new BeaconManufacturerValidator(),
   model: new BeaconModelValidator(),
   hexId: new BeaconHexIdValidator(),
   moreVesselDetails: new MoreVesselDetailsValidator(),
+  maritimePleasureVesselUse: new MaritimePleasureVesselUseValidator(),
 };

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -122,10 +122,10 @@ export class OtherPleasureVesselTextValidator extends FieldValidator {
     super();
     this._rules = [
       // TODO Conditional rule: if OtherPleasureVessel is selected, field is required
-      {
-        errorMessage: "Other pleasure vessel text is a required field",
-        predicateFn: (value) => value.length === 0,
-      },
+      // {
+      //   errorMessage: "Other pleasure vessel text is a required field",
+      //   predicateFn: (value) => value.length === 0,
+      // },
     ];
   }
 }

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -116,6 +116,7 @@ export class OtherPleasureVesselTextValidator extends FieldValidator {
   constructor() {
     super();
     this._rules = [
+      // TODO Conditional rule: if OtherPleasureVessel is selected, field is required
       {
         errorMessage: "Other pleasure vessel text is a required field",
         predicateFn: (value) => value.length === 0,

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -112,10 +112,23 @@ export class MaritimePleasureVesselUseValidator extends FieldValidator {
   }
 }
 
+export class OtherPleasureVesselTextValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Other pleasure vessel text is a required field",
+        predicateFn: (value) => value.length === 0,
+      },
+    ];
+  }
+}
+
 export const fieldValidatorLookup = {
   manufacturer: new BeaconManufacturerValidator(),
   model: new BeaconModelValidator(),
   hexId: new BeaconHexIdValidator(),
   moreVesselDetails: new MoreVesselDetailsValidator(),
   maritimePleasureVesselUse: new MaritimePleasureVesselUseValidator(),
+  otherPleasureVesselText: new OtherPleasureVesselTextValidator(),
 };

--- a/src/lib/formCache.ts
+++ b/src/lib/formCache.ts
@@ -1,16 +1,14 @@
 import { Beacon, BeaconIntent, Vessel } from "./types";
 
 // Convenience type
-export type BeaconCacheEntry = Partial<Beacon> & {
+export type CacheEntry = Partial<Beacon & Vessel> & {
   beaconIntent?: BeaconIntent;
 };
 
-export type VesselCacheEntry = Partial<Vessel>;
-
 export interface IFormCache {
-  update(id: string, formData?: BeaconCacheEntry): void;
+  update(id: string, formData?: CacheEntry): void;
 
-  get(id: string): BeaconCacheEntry;
+  get(id: string): CacheEntry;
 }
 
 export class FormCacheFactory {
@@ -26,14 +24,14 @@ export class FormCacheFactory {
 }
 
 class FormCache implements IFormCache {
-  private _byId: Record<string, BeaconCacheEntry> = {};
+  private _byId: Record<string, CacheEntry> = {};
 
-  public update(id: string, formData: BeaconCacheEntry = {}): void {
+  public update(id: string, formData: CacheEntry = {}): void {
     this._byId[id] = this._byId[id] || {};
     Object.assign(this._byId[id], formData);
   }
 
-  public get(id: string): BeaconCacheEntry {
+  public get(id: string): CacheEntry {
     return this._byId[id] || {};
   }
 }

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -19,7 +19,7 @@ export class FormValidator {
     return fields.reduce((validatorResponse, [fieldId, value]) => {
       if (!(fieldId in validatorLookup))
         throw new ReferenceError(
-          `${fieldId} not found in validatorLookup.  Create a new validator key/value pair for this field?`
+          `${fieldId} not found in fieldValidatorLookup.  Create a new validator key/value pair for this field?`
         );
 
       validatorResponse[fieldId] = {

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -1,30 +1,76 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { BeaconCacheEntry } from "./formCache";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from "next";
+import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
+import { CacheEntry } from "./formCache";
 import { FormValidator } from "./formValidator";
-import { updateFormCache, withCookieRedirect } from "./middleware";
+import {
+  getCache,
+  parseFormData,
+  updateFormCache,
+  withCookieRedirect,
+} from "./middleware";
+
+type TransformFunction = (formData: CacheEntry) => CacheEntry;
+
+interface FormPageProps {
+  formData: CacheEntry;
+  needsValidation: boolean;
+}
 
 export const handlePageRequest = (
-  destinationIfValid: string
+  destinationIfValid: string,
+  transformFunction: TransformFunction = (formData) => formData
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
-    const formData: BeaconCacheEntry = await updateFormCache(context);
-
     const userDidSubmitForm = context.req.method === "POST";
-    const formIsValid = !FormValidator.hasErrors(formData);
 
-    if (userDidSubmitForm && formIsValid) {
-      return {
-        redirect: {
-          statusCode: 303,
-          destination: destinationIfValid,
-        },
-      };
+    if (userDidSubmitForm) {
+      return handlePostRequest(context, destinationIfValid, transformFunction);
     }
 
+    return handleGetRequest(context.req.cookies);
+  });
+
+const handleGetRequest = (
+  cookies: NextApiRequestCookies
+): GetServerSidePropsResult<FormPageProps> => {
+  return {
+    props: {
+      formData: getCache(cookies),
+      needsValidation: false,
+    },
+  };
+};
+
+export const handlePostRequest = async (
+  context: GetServerSidePropsContext,
+  destinationIfValid: string,
+  transformFunction: TransformFunction = (formData) => formData
+): Promise<GetServerSidePropsResult<FormPageProps>> => {
+  const transformedFormData = transformFunction(
+    await parseFormData(context.req)
+  );
+
+  updateFormCache(context.req.cookies, transformedFormData);
+
+  const formIsValid = !FormValidator.hasErrors(transformedFormData);
+
+  if (formIsValid) {
     return {
-      props: {
-        formData,
-        needsValidation: userDidSubmitForm,
+      redirect: {
+        statusCode: 303,
+        destination: destinationIfValid,
       },
     };
-  });
+  }
+
+  return {
+    props: {
+      formData: transformedFormData,
+      needsValidation: true,
+    },
+  };
+};

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -1,0 +1,30 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { BeaconCacheEntry } from "./formCache";
+import { FormValidator } from "./formValidator";
+import { updateFormCache, withCookieRedirect } from "./middleware";
+
+export const handlePageRequest = (
+  destinationIfValid: string
+): GetServerSideProps =>
+  withCookieRedirect(async (context: GetServerSidePropsContext) => {
+    const formData: BeaconCacheEntry = await updateFormCache(context);
+
+    const userDidSubmitForm = context.req.method === "POST";
+    const formIsValid = !FormValidator.hasErrors(formData);
+
+    if (userDidSubmitForm && formIsValid) {
+      return {
+        redirect: {
+          statusCode: 303,
+          destination: destinationIfValid,
+        },
+      };
+    }
+
+    return {
+      props: {
+        formData,
+        needsValidation: userDidSubmitForm,
+      },
+    };
+  });

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -18,8 +18,6 @@ export function withCookieRedirect<T>(callback: GetServerSideProps<T>) {
   ): Promise<GetServerSidePropsResult<T>> => {
     const cookies: NextApiRequestCookies = context.req.cookies;
 
-    console.log("the real withCookieRedirect was called");
-
     if (!cookies || !cookies[formSubmissionCookieId]) {
       return {
         redirect: {

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -8,7 +8,7 @@ import {
 import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
 import parse from "urlencoded-body-parser";
 import { v4 as uuidv4 } from "uuid";
-import { BeaconCacheEntry, FormCacheFactory, IFormCache } from "./formCache";
+import { CacheEntry, FormCacheFactory, IFormCache } from "./formCache";
 import { formSubmissionCookieId } from "./types";
 import { toArray } from "./utils";
 
@@ -87,7 +87,7 @@ export async function parseFormData<T>(request: IncomingMessage): Promise<T> {
 export const getCache = (
   cookies: NextApiRequestCookies,
   cache: IFormCache = FormCacheFactory.getCache()
-): BeaconCacheEntry => {
+): CacheEntry => {
   const submissionId: string = cookies[formSubmissionCookieId];
   return cache.get(submissionId);
 };

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -18,6 +18,8 @@ export function withCookieRedirect<T>(callback: GetServerSideProps<T>) {
   ): Promise<GetServerSidePropsResult<T>> => {
     const cookies: NextApiRequestCookies = context.req.cookies;
 
+    console.log("the real withCookieRedirect was called");
+
     if (!cookies || !cookies[formSubmissionCookieId]) {
       return {
         redirect: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,6 +30,8 @@ export interface Beacon {
 
 export interface Vessel {
   moreVesselDetails: string;
+  maritimePleasureVesselUse: string;
+  otherPleasureVesselText: string;
 }
 
 export const formSubmissionCookieId = "submissionId";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,3 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import { BeaconCacheEntry } from "./formCache";
-import { FormValidator } from "./formValidator";
-import { updateFormCache, withCookieRedirect } from "./middleware";
-
 /**
  * Convenience function for converting a single or array of a given type into an array with nullish values removed.
  *
@@ -27,29 +22,3 @@ export const ensureFormDataHasKeys = (
 
   return newFormData;
 };
-
-export const handleFormSubmission = (
-  destinationIfValid: string
-): GetServerSideProps =>
-  withCookieRedirect(async (context: GetServerSidePropsContext) => {
-    const formData: BeaconCacheEntry = await updateFormCache(context);
-
-    const userDidSubmitForm = context.req.method === "POST";
-    const formIsValid = !FormValidator.hasErrors(formData);
-
-    if (userDidSubmitForm && formIsValid) {
-      return {
-        redirect: {
-          statusCode: 303,
-          destination: destinationIfValid,
-        },
-      };
-    }
-
-    return {
-      props: {
-        formData,
-        needsValidation: userDidSubmitForm,
-      },
-    };
-  });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { GetServerSidePropsContext } from "next";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { BeaconCacheEntry } from "./formCache";
 import { FormValidator } from "./formValidator";
 import { updateFormCache, withCookieRedirect } from "./middleware";
@@ -28,7 +28,9 @@ export const ensureFormDataHasKeys = (
   return newFormData;
 };
 
-export const handleFormSubmission = (destinationIfValid: string) =>
+export const handleFormSubmission = (
+  destinationIfValid: string
+): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
     const formData: BeaconCacheEntry = await updateFormCache(context);
 

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import {
@@ -21,8 +21,7 @@ import { Input } from "../../components/Input";
 import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import { BeaconCacheEntry } from "../../lib/formCache";
-import { updateFormCache, withCookieRedirect } from "../../lib/middleware";
+import { handlePageRequest } from "../../lib/handlePageRequest";
 
 const BeaconInformationPage: FunctionComponent = (): JSX.Element => {
   const pageHeading = "Beacon information";
@@ -193,31 +192,8 @@ const BeaconLastServicedDate: FunctionComponent = (): JSX.Element => (
   </DateListInput>
 );
 
-export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
-    const formData: BeaconCacheEntry = await updateFormCache(context);
-
-    const userDidSubmitForm = context.req.method === "POST";
-    // TODO: Add form validation to this page
-    // const formIsValid = !FormValidator.hasErrors(formData);
-    const formIsValid = true;
-
-    if (userDidSubmitForm && formIsValid) {
-      return {
-        redirect: {
-          statusCode: 303,
-          destination: "/register-a-beacon/primary-beacon-use",
-        },
-      };
-    }
-
-    return {
-      props: {
-        formData,
-        needsValidation: userDidSubmitForm,
-      },
-    };
-  }
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/primary-beacon-use"
 );
 
 export default BeaconInformationPage;

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps } from "next";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import {
@@ -21,7 +21,8 @@ import { Input } from "../../components/Input";
 import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import { withCookieRedirect } from "../../lib/middleware";
+import { BeaconCacheEntry } from "../../lib/formCache";
+import { updateFormCache, withCookieRedirect } from "../../lib/middleware";
 
 const BeaconInformationPage: FunctionComponent = (): JSX.Element => (
   <>
@@ -120,7 +121,7 @@ const BeaconBatteryExpiryDate: FunctionComponent = (): JSX.Element => (
           id="beaconBatteryExpiryDateMonth"
           name="beaconBatteryExpiryDateonth"
           dateType={DateType.MONTH}
-        ></DateInput>
+        />
       </FormGroup>
     </DateListItem>
 
@@ -136,7 +137,7 @@ const BeaconBatteryExpiryDate: FunctionComponent = (): JSX.Element => (
           id="beaconBatteryExpiryDateYear"
           name="beaconBatteryExpiryDateYear"
           dateType={DateType.YEAR}
-        ></DateInput>
+        />
       </FormGroup>
     </DateListItem>
   </DateListInput>
@@ -165,7 +166,7 @@ const BeaconLastServicedDate: FunctionComponent = (): JSX.Element => (
           id="beaconLastServicedDateMonth"
           name="beaconLastServicedDateMonth"
           dateType={DateType.MONTH}
-        ></DateInput>
+        />
       </FormGroup>
     </DateListItem>
 
@@ -181,16 +182,35 @@ const BeaconLastServicedDate: FunctionComponent = (): JSX.Element => (
           id="beaconLastServicedDateYear"
           name="beaconLastServicedDateYear"
           dateType={DateType.YEAR}
-        ></DateInput>
+        />
       </FormGroup>
     </DateListItem>
   </DateListInput>
 );
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async () => {
+  async (context: GetServerSidePropsContext) => {
+    const formData: BeaconCacheEntry = await updateFormCache(context);
+
+    const userDidSubmitForm = context.req.method === "POST";
+    // TODO: Add form validation to this page
+    // const formIsValid = !FormValidator.hasErrors(formData);
+    const formIsValid = true;
+
+    if (userDidSubmitForm && formIsValid) {
+      return {
+        redirect: {
+          statusCode: 303,
+          destination: "/register-a-beacon/primary-beacon-use",
+        },
+      };
+    }
+
     return {
-      props: {},
+      props: {
+        formData,
+        needsValidation: userDidSubmitForm,
+      },
     };
   }
 );

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -64,7 +64,10 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
         <Grid
           mainContent={
             <>
-              {needsValidation && <FormErrorSummary errors={errors} />}
+              <FormErrorSummary
+                errors={errors}
+                needsValidation={needsValidation}
+              />
               <Form action="/register-a-beacon/check-beacon-details">
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -22,7 +22,7 @@ import { Input } from "../../components/Input";
 import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import { BeaconCacheEntry } from "../../lib/formCache";
+import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import {
   getCache,
@@ -33,7 +33,7 @@ import {
 import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface CheckBeaconDetailsProps {
-  formData: BeaconCacheEntry;
+  formData: CacheEntry;
   needsValidation?: boolean;
 }
 
@@ -168,8 +168,8 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
 const handlePostRequest = async (
   context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<CheckBeaconDetailsProps>> => {
-  const rawFormData: BeaconCacheEntry = await parseFormData(context.req);
-  const formData: BeaconCacheEntry = {
+  const rawFormData: CacheEntry = await parseFormData(context.req);
+  const formData: CacheEntry = {
     ...rawFormData,
     hexId: (rawFormData["hexId"] || "").toUpperCase(),
   };

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -7,7 +7,7 @@ import { IfYouNeedHelp } from "../../components/Mca";
 import { NotificationBannerSuccess } from "../../components/NotificationBanner";
 import { SummaryList, SummaryListItem } from "../../components/SummaryList";
 import { PageHeading } from "../../components/Typography";
-import { BeaconCacheEntry } from "../../lib/formCache";
+import { CacheEntry } from "../../lib/formCache";
 import {
   getCache,
   parseFormData,
@@ -101,14 +101,14 @@ const BeaconSummary: FunctionComponent<BeaconDetailsSummaryProps> = ({
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
   async (context: GetServerSidePropsContext) => {
     if (context.req.method === "POST") {
-      const formData: BeaconCacheEntry = await parseFormData(context.req);
+      const formData: CacheEntry = await parseFormData(context.req);
       updateFormCache(context.req.cookies, formData);
 
       return {
         props: { ...formData },
       };
     } else if (context.req.method === "GET") {
-      const existingState: BeaconCacheEntry = getCache(context.req.cookies);
+      const existingState: CacheEntry = getCache(context.req.cookies);
 
       return { props: { ...existingState } };
     }

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -15,7 +15,7 @@ import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { TextareaCharacterCount } from "../../components/Textarea";
-import { VesselCacheEntry } from "../../lib/formCache";
+import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import {
   parseFormData,
@@ -25,7 +25,7 @@ import {
 import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface MoreVesselDetailsProps {
-  formData: VesselCacheEntry;
+  formData: CacheEntry;
   needsValidation: boolean;
 }
 
@@ -105,7 +105,7 @@ const MoreVesselDetailsTextArea: FunctionComponent<MoreVesselDetailsTextAreaProp
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
   async (context: GetServerSidePropsContext) => {
-    const formData: VesselCacheEntry = await parseFormData(context.req);
+    const formData: CacheEntry = await parseFormData(context.req);
     updateFormCache(context.req.cookies, formData);
 
     const userDidSubmitForm = context.req.method === "POST";

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -55,7 +55,10 @@ const MoreVesselDetails: FunctionComponent<MoreVesselDetailsProps> = ({
         <Grid
           mainContent={
             <>
-              {needsValidation && <FormErrorSummary errors={errors} />}
+              <FormErrorSummary
+                errors={errors}
+                needsValidation={needsValidation}
+              />
               <Form action="/register-a-beacon/more-vessel-details">
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -2,6 +2,10 @@ import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import {
+  FieldErrorList,
+  FormErrorSummary,
+} from "../../components/ErrorSummary";
+import {
   Form,
   FormFieldset,
   FormGroup,
@@ -19,6 +23,7 @@ import {
 import { VesselCacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
+import { updateFormCache } from "../../lib/middleware";
 import { MaritimePleasureVessel } from "../../lib/types";
 import { ensureFormDataHasKeys } from "../../lib/utils";
 
@@ -46,7 +51,16 @@ const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
       <Grid
         mainContent={
           <>
-            <BeaconUseForm checkedValue={formData.maritimePleasureVesselUse} />
+            {needsValidation && <FormErrorSummary errors={errors} />}
+            <BeaconUseForm
+              checkedValue={formData.maritimePleasureVesselUse}
+              formData={formData}
+              showErrors={needsValidation && FormValidator.hasErrors(formData)}
+              errorMessages={
+                FormValidator.validate(formData).maritimePleasureVesselUse
+                  .errorMessages
+              }
+            />
 
             <IfYouNeedHelp />
           </>
@@ -57,11 +71,17 @@ const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
 };
 
 interface BeaconUseFormProps {
+  formData: VesselCacheEntry;
   checkedValue: string | null;
+  showErrors: boolean;
+  errorMessages: string[];
 }
 
 const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
+  formData,
   checkedValue = null,
+  showErrors,
+  errorMessages,
 }: BeaconUseFormProps): JSX.Element => {
   const setCheckedIfUserSelected = (userSelectedValue, componentValue) => {
     return {
@@ -71,96 +91,102 @@ const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
 
   return (
     <Form action="/register-a-beacon/primary-beacon-use">
-      <FormFieldset>
-        <FormLegendPageHeading>
-          What type of maritime pleasure vessel will you mostly use this beacon
-          on?
-        </FormLegendPageHeading>
-      </FormFieldset>
-      <RadioListConditional>
-        <RadioListItemHint
-          id="motor-vessel"
-          name="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.MOTOR}
-          hintText="E.g. Speedboat, RIB"
-          inputHtmlAttributes={setCheckedIfUserSelected(
-            checkedValue,
-            MaritimePleasureVessel.MOTOR
-          )}
-        >
-          Motor vessel
-        </RadioListItemHint>
-        <RadioListItemHint
-          id="sailing-vessel"
-          name="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.SAILING}
-          hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-          inputHtmlAttributes={setCheckedIfUserSelected(
-            checkedValue,
-            MaritimePleasureVessel.SAILING
-          )}
-        >
-          Sailing vessel
-        </RadioListItemHint>
-        <RadioListItemHint
-          id="rowing-vessel"
-          name="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.ROWING}
-          hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-          inputHtmlAttributes={setCheckedIfUserSelected(
-            checkedValue,
-            MaritimePleasureVessel.ROWING
-          )}
-        >
-          Rowing vessel
-        </RadioListItemHint>
-        <RadioListItemHint
-          id="small-unpowered-vessel"
-          name="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.SMALL_UNPOWERED}
-          hintText="E.g. Canoe, Kayak"
-          inputHtmlAttributes={setCheckedIfUserSelected(
-            checkedValue,
-            MaritimePleasureVessel.SMALL_UNPOWERED
-          )}
-        >
-          Small unpowered vessel
-        </RadioListItemHint>
-        <RadioListItemHint
-          id="other-pleasure-vessel"
-          name="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.OTHER}
-          hintText="E.g. Surfboard, Kitesurfing"
-          inputHtmlAttributes={{
-            ...{
-              "data-aria-controls": "conditional-other-pleasure-vessel",
-            },
-            ...setCheckedIfUserSelected(
+      <FormGroup showErrors={showErrors}>
+        <FormFieldset>
+          <FormLegendPageHeading>
+            What type of maritime pleasure vessel will you mostly use this
+            beacon on?
+          </FormLegendPageHeading>
+        </FormFieldset>
+        {showErrors && <FieldErrorList errorMessages={errorMessages} />}
+        <RadioListConditional>
+          <RadioListItemHint
+            id="motor-vessel"
+            name="maritimePleasureVesselUse"
+            value={MaritimePleasureVessel.MOTOR}
+            hintText="E.g. Speedboat, RIB"
+            inputHtmlAttributes={setCheckedIfUserSelected(
               checkedValue,
-              MaritimePleasureVessel.OTHER
-            ),
-          }}
-        >
-          Other pleasure vessel
-        </RadioListItemHint>
-        <RadioListItemConditional id="conditional-other-pleasure-vessel">
-          <FormGroup>
-            <Input
-              id="other-pleasure-vessel-text"
-              name="otherPleasureVesselText"
-              label="What sort of vessel is it?"
-            />
-          </FormGroup>
-        </RadioListItemConditional>
-      </RadioListConditional>
+              MaritimePleasureVessel.MOTOR
+            )}
+          >
+            Motor vessel
+          </RadioListItemHint>
+          <RadioListItemHint
+            id="sailing-vessel"
+            name="maritimePleasureVesselUse"
+            value={MaritimePleasureVessel.SAILING}
+            hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+            inputHtmlAttributes={setCheckedIfUserSelected(
+              checkedValue,
+              MaritimePleasureVessel.SAILING
+            )}
+          >
+            Sailing vessel
+          </RadioListItemHint>
+          <RadioListItemHint
+            id="rowing-vessel"
+            name="maritimePleasureVesselUse"
+            value={MaritimePleasureVessel.ROWING}
+            hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+            inputHtmlAttributes={setCheckedIfUserSelected(
+              checkedValue,
+              MaritimePleasureVessel.ROWING
+            )}
+          >
+            Rowing vessel
+          </RadioListItemHint>
+          <RadioListItemHint
+            id="small-unpowered-vessel"
+            name="maritimePleasureVesselUse"
+            value={MaritimePleasureVessel.SMALL_UNPOWERED}
+            hintText="E.g. Canoe, Kayak"
+            inputHtmlAttributes={setCheckedIfUserSelected(
+              checkedValue,
+              MaritimePleasureVessel.SMALL_UNPOWERED
+            )}
+          >
+            Small unpowered vessel
+          </RadioListItemHint>
+          <RadioListItemHint
+            id="other-pleasure-vessel"
+            name="maritimePleasureVesselUse"
+            value={MaritimePleasureVessel.OTHER}
+            hintText="E.g. Surfboard, Kitesurfing"
+            inputHtmlAttributes={{
+              ...{
+                "data-aria-controls": "conditional-other-pleasure-vessel",
+              },
+              ...setCheckedIfUserSelected(
+                checkedValue,
+                MaritimePleasureVessel.OTHER
+              ),
+            }}
+          >
+            Other pleasure vessel
+          </RadioListItemHint>
+          <RadioListItemConditional id="conditional-other-pleasure-vessel">
+            <FormGroup>
+              <Input
+                id="other-pleasure-vessel-text"
+                name="otherPleasureVesselText"
+                label="What sort of vessel is it?"
+                defaultValue={formData.otherPleasureVesselText}
+              />
+            </FormGroup>
+          </RadioListItemConditional>
+        </RadioListConditional>
+      </FormGroup>
 
       <Button buttonText="Continue" />
     </Form>
   );
 };
 
-export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/about-the-vessel"
-);
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const formData = await updateFormCache(context);
+
+  return handlePageRequest("/register-a-beacon/about-the-vessel")(context);
+};
 
 export default PrimaryBeaconUse;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -20,16 +20,22 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
-import { VesselCacheEntry } from "../../lib/formCache";
+import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
-import { updateFormCache } from "../../lib/middleware";
 import { MaritimePleasureVessel } from "../../lib/types";
 import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface PrimaryBeaconUseProps {
-  formData: VesselCacheEntry;
+  formData: CacheEntry;
   needsValidation: boolean;
+}
+
+interface BeaconUseFormProps {
+  formData: CacheEntry;
+  checkedValue: string | null;
+  showErrors: boolean;
+  errorMessages: string[];
 }
 
 const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
@@ -46,7 +52,11 @@ const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
 
   return (
     <Layout
+      title={
+        "What type of maritime pleasure vessel will you mostly use this beacon on?"
+      }
       navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+      pageHasErrors={errors.length > 0 && needsValidation}
     >
       <Grid
         mainContent={
@@ -69,13 +79,6 @@ const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
     </Layout>
   );
 };
-
-interface BeaconUseFormProps {
-  formData: VesselCacheEntry;
-  checkedValue: string | null;
-  showErrors: boolean;
-  errorMessages: string[];
-}
 
 const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
   formData,
@@ -183,10 +186,16 @@ const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const formData = await updateFormCache(context);
-
-  return handlePageRequest("/register-a-beacon/about-the-vessel")(context);
+const ensureMaritimePleasureVesselUseIsSubmitted = (formData) => {
+  return {
+    ...formData,
+    maritimePleasureVesselUse: formData["maritimePleasureVesselUse"] || "",
+  };
 };
+
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/beacon-information",
+  ensureMaritimePleasureVesselUseIsSubmitted
+);
 
 export default PrimaryBeaconUse;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -61,7 +61,10 @@ const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
       <Grid
         mainContent={
           <>
-            {needsValidation && <FormErrorSummary errors={errors} />}
+            <FormErrorSummary
+              errors={errors}
+              needsValidation={needsValidation}
+            />
             <BeaconUseForm
               checkedValue={formData.maritimePleasureVesselUse}
               formData={formData}

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import {
@@ -16,10 +16,8 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
-import { BeaconCacheEntry } from "../../lib/formCache";
-import { FormValidator } from "../../lib/formValidator";
-import { updateFormCache, withCookieRedirect } from "../../lib/middleware";
 import { MaritimePleasureVessel } from "../../lib/types";
+import { handleFormSubmission } from "../../lib/utils";
 
 const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => (
   <Layout
@@ -104,29 +102,8 @@ const BeaconUseForm: FunctionComponent = (): JSX.Element => (
   </Form>
 );
 
-export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
-    const formData: BeaconCacheEntry = await updateFormCache(context);
-
-    const userDidSubmitForm = context.req.method === "POST";
-    const formIsValid = !FormValidator.hasErrors(formData);
-
-    if (userDidSubmitForm && formIsValid) {
-      return {
-        redirect: {
-          statusCode: 303,
-          destination: "/register-a-beacon/about-the-vessel",
-        },
-      };
-    }
-
-    return {
-      props: {
-        formData,
-        needsValidation: userDidSubmitForm,
-      },
-    };
-  }
+export const getServerSideProps: GetServerSideProps = handleFormSubmission(
+  "/register-a-beacon/about-the-vessel"
 );
 
 export default PrimaryBeaconUse;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -194,7 +194,7 @@ const ensureMaritimePleasureVesselUseIsSubmitted = (formData) => {
 };
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/beacon-information",
+  "/register-a-beacon/about-the-vessel",
   ensureMaritimePleasureVesselUseIsSubmitted
 );
 

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -16,91 +16,148 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
+import { VesselCacheEntry } from "../../lib/formCache";
+import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
 import { MaritimePleasureVessel } from "../../lib/types";
+import { ensureFormDataHasKeys } from "../../lib/utils";
 
-const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => (
-  <Layout
-    navigation={<BackButton href="/register-a-beacon/beacon-information" />}
-  >
-    <Grid
-      mainContent={
-        <>
-          <BeaconUseForm />
+interface PrimaryBeaconUseProps {
+  formData: VesselCacheEntry;
+  needsValidation: boolean;
+}
 
-          <IfYouNeedHelp />
-        </>
-      }
-    />
-  </Layout>
-);
+const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
+  formData,
+  needsValidation = false,
+}: PrimaryBeaconUseProps): JSX.Element => {
+  formData = ensureFormDataHasKeys(
+    formData,
+    "maritimePleasureVesselUse",
+    "otherPleasureVesselText"
+  );
 
-const BeaconUseForm: FunctionComponent = (): JSX.Element => (
-  <Form action="/register-a-beacon/primary-beacon-use">
-    <FormFieldset>
-      <FormLegendPageHeading>
-        What type of maritime pleasure vessel will you mostly use this beacon
-        on?
-      </FormLegendPageHeading>
-    </FormFieldset>
-    <RadioListConditional>
-      <RadioListItemHint
-        id="motor-vessel"
-        name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.MOTOR}
-        hintText="E.g. Speedboat, RIB"
-      >
-        Motor vessel
-      </RadioListItemHint>
-      <RadioListItemHint
-        id="sailing-vessel"
-        name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.SAILING}
-        hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-      >
-        Sailing vessel
-      </RadioListItemHint>
-      <RadioListItemHint
-        id="rowing-vessel"
-        name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.ROWING}
-        hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-      >
-        Rowing vessel
-      </RadioListItemHint>
-      <RadioListItemHint
-        id="small-unpowered-vessel"
-        name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.SMALL_UNPOWERED}
-        hintText="E.g. Canoe, Kayak"
-      >
-        Small unpowered vessel
-      </RadioListItemHint>
-      <RadioListItemHint
-        id="other-pleasure-vessel"
-        name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.OTHER}
-        hintText="E.g. Surfboard, Kitesurfing"
-        inputHtmlAttributes={{
-          "data-aria-controls": "conditional-other-pleasure-vessel",
-        }}
-      >
-        Other pleasure vessel
-      </RadioListItemHint>
-      <RadioListItemConditional id="conditional-other-pleasure-vessel">
-        <FormGroup>
-          <Input
-            id="other-pleasure-vessel-text"
-            name="otherPleasureVesselText"
-            label="What sort of vessel is it?"
-          />
-        </FormGroup>
-      </RadioListItemConditional>
-    </RadioListConditional>
+  const errors = FormValidator.errorSummary(formData);
 
-    <Button buttonText="Continue" />
-  </Form>
-);
+  return (
+    <Layout
+      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+    >
+      <Grid
+        mainContent={
+          <>
+            <BeaconUseForm checkedValue={formData.maritimePleasureVesselUse} />
+
+            <IfYouNeedHelp />
+          </>
+        }
+      />
+    </Layout>
+  );
+};
+
+interface BeaconUseFormProps {
+  checkedValue: string | null;
+}
+
+const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
+  checkedValue = null,
+}: BeaconUseFormProps): JSX.Element => {
+  const setCheckedIfUserSelected = (userSelectedValue, componentValue) => {
+    return {
+      defaultChecked: userSelectedValue === componentValue,
+    };
+  };
+
+  return (
+    <Form action="/register-a-beacon/primary-beacon-use">
+      <FormFieldset>
+        <FormLegendPageHeading>
+          What type of maritime pleasure vessel will you mostly use this beacon
+          on?
+        </FormLegendPageHeading>
+      </FormFieldset>
+      <RadioListConditional>
+        <RadioListItemHint
+          id="motor-vessel"
+          name="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.MOTOR}
+          hintText="E.g. Speedboat, RIB"
+          inputHtmlAttributes={setCheckedIfUserSelected(
+            checkedValue,
+            MaritimePleasureVessel.MOTOR
+          )}
+        >
+          Motor vessel
+        </RadioListItemHint>
+        <RadioListItemHint
+          id="sailing-vessel"
+          name="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.SAILING}
+          hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+          inputHtmlAttributes={setCheckedIfUserSelected(
+            checkedValue,
+            MaritimePleasureVessel.SAILING
+          )}
+        >
+          Sailing vessel
+        </RadioListItemHint>
+        <RadioListItemHint
+          id="rowing-vessel"
+          name="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.ROWING}
+          hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+          inputHtmlAttributes={setCheckedIfUserSelected(
+            checkedValue,
+            MaritimePleasureVessel.ROWING
+          )}
+        >
+          Rowing vessel
+        </RadioListItemHint>
+        <RadioListItemHint
+          id="small-unpowered-vessel"
+          name="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.SMALL_UNPOWERED}
+          hintText="E.g. Canoe, Kayak"
+          inputHtmlAttributes={setCheckedIfUserSelected(
+            checkedValue,
+            MaritimePleasureVessel.SMALL_UNPOWERED
+          )}
+        >
+          Small unpowered vessel
+        </RadioListItemHint>
+        <RadioListItemHint
+          id="other-pleasure-vessel"
+          name="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.OTHER}
+          hintText="E.g. Surfboard, Kitesurfing"
+          inputHtmlAttributes={{
+            ...{
+              "data-aria-controls": "conditional-other-pleasure-vessel",
+            },
+            ...setCheckedIfUserSelected(
+              checkedValue,
+              MaritimePleasureVessel.OTHER
+            ),
+          }}
+        >
+          Other pleasure vessel
+        </RadioListItemHint>
+        <RadioListItemConditional id="conditional-other-pleasure-vessel">
+          <FormGroup>
+            <Input
+              id="other-pleasure-vessel-text"
+              name="otherPleasureVesselText"
+              label="What sort of vessel is it?"
+            />
+          </FormGroup>
+        </RadioListItemConditional>
+      </RadioListConditional>
+
+      <Button buttonText="Continue" />
+    </Form>
+  );
+};
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
   "/register-a-beacon/about-the-vessel"

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -1,10 +1,7 @@
 import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
-import {
-  FieldErrorList,
-  FormErrorSummary,
-} from "../../components/ErrorSummary";
+import { FormErrorSummary } from "../../components/ErrorSummary";
 import {
   Form,
   FormFieldset,
@@ -97,14 +94,13 @@ const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
 
   return (
     <Form action="/register-a-beacon/primary-beacon-use">
-      <FormGroup showErrors={showErrors}>
+      <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
         <FormFieldset>
           <FormLegendPageHeading>
             What type of maritime pleasure vessel will you mostly use this
             beacon on?
           </FormLegendPageHeading>
         </FormFieldset>
-        {showErrors && <FieldErrorList errorMessages={errorMessages} />}
         <RadioListConditional>
           <RadioListItemHint
             id="motor-vessel"

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -16,8 +16,8 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
+import { handlePageRequest } from "../../lib/handlePageRequest";
 import { MaritimePleasureVessel } from "../../lib/types";
-import { handleFormSubmission } from "../../lib/utils";
 
 const PrimaryBeaconUse: FunctionComponent = (): JSX.Element => (
   <Layout
@@ -102,7 +102,7 @@ const BeaconUseForm: FunctionComponent = (): JSX.Element => (
   </Form>
 );
 
-export const getServerSideProps: GetServerSideProps = handleFormSubmission(
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
   "/register-a-beacon/about-the-vessel"
 );
 

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -153,7 +153,9 @@ describe("MaritimePleasureVesselUseValidator", () => {
 
 describe("OtherPleasureVesselTextValidator", () => {
   describe("validate", () => {
-    it("should return false if value is an empty string", () => {
+    xit("should return false if value is an empty string", () => {
+      // Skipped pending implementation of conditional form validation
+      // (e.g. only validate X if radio button Y is checked)
       const otherPleasureVesselTextValidator = new OtherPleasureVesselTextValidator();
       const invalidValue = "";
 

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -3,6 +3,7 @@ import {
   BeaconManufacturerValidator,
   BeaconModelValidator,
   MaritimePleasureVesselUseValidator,
+  OtherPleasureVesselTextValidator,
 } from "../../src/lib/fieldValidators";
 
 describe("BeaconModelValidator", () => {
@@ -127,6 +128,22 @@ describe("MaritimePleasureVesselUseValidator", () => {
         expect(validationResponse.valid).toBe(false);
         expect(validationResponse.errorMessages.length).toBe(1);
       });
+    });
+  });
+});
+
+describe("OtherPleasureVesselTextValidator", () => {
+  describe("validate", () => {
+    it("should return false if value is an empty string", () => {
+      const otherPleasureVesselTextValidator = new OtherPleasureVesselTextValidator();
+      const invalidValue = "";
+
+      const validationResponse = otherPleasureVesselTextValidator.validate(
+        invalidValue
+      );
+
+      expect(validationResponse.valid).toBe(false);
+      expect(validationResponse.errorMessages.length).toBe(1);
     });
   });
 });

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -2,6 +2,7 @@ import {
   BeaconHexIdValidator,
   BeaconManufacturerValidator,
   BeaconModelValidator,
+  MaritimePleasureVesselUseValidator,
 } from "../../src/lib/fieldValidators";
 
 describe("BeaconModelValidator", () => {
@@ -96,6 +97,36 @@ describe("BeaconHexIdValidator", () => {
 
       expect(validationResponse.valid).toBe(true);
       expect(validationResponse.errorMessages.length).toBe(0);
+    });
+  });
+});
+
+describe("MaritimePleasureVesselUseValidator", () => {
+  describe("validate", () => {
+    it("should return false if value is an empty string", () => {
+      const maritimePleasureVesselUseValidator = new MaritimePleasureVesselUseValidator();
+      const invalidValue = "";
+
+      const validationResponse = maritimePleasureVesselUseValidator.validate(
+        invalidValue
+      );
+
+      expect(validationResponse.valid).toBe(false);
+      expect(validationResponse.errorMessages.length).toBe(1);
+    });
+
+    it("should return false if value is not in the enum", () => {
+      const maritimePleasureVesselUseValidator = new MaritimePleasureVesselUseValidator();
+      const invalidValues = ["PARACHUTE", "TOBOGGAN", "SNOW PLOUGH", "BICYCLE"];
+
+      invalidValues.forEach((invalidValue) => {
+        const validationResponse = maritimePleasureVesselUseValidator.validate(
+          invalidValue
+        );
+
+        expect(validationResponse.valid).toBe(false);
+        expect(validationResponse.errorMessages.length).toBe(1);
+      });
     });
   });
 });

--- a/test/lib/formCache.test.ts
+++ b/test/lib/formCache.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import {
-  BeaconCacheEntry,
+  CacheEntry,
   FormCacheFactory,
   IFormCache,
 } from "../../src/lib/formCache";
@@ -34,27 +34,27 @@ describe("FormCache", () => {
   });
 
   it("should set the cache for the given id", () => {
-    const formData: BeaconCacheEntry = { manufacturer: "ASOS" };
+    const formData: CacheEntry = { manufacturer: "ASOS" };
     cache.update(id, formData);
 
     expect(cache.get(id)).toStrictEqual(formData);
   });
 
   it("should update the cache object with the provided updated value", () => {
-    const formData: BeaconCacheEntry = { manufacturer: "ASOS" };
+    const formData: CacheEntry = { manufacturer: "ASOS" };
     cache.update(id, formData);
 
-    const updatedFormData: BeaconCacheEntry = { manufacturer: "TOPSHOP" };
+    const updatedFormData: CacheEntry = { manufacturer: "TOPSHOP" };
     cache.update(id, updatedFormData);
 
     expect(cache.get(id)).toStrictEqual(updatedFormData);
   });
 
   it("should only update the provided form fields", () => {
-    const formData: BeaconCacheEntry = { manufacturer: "ASOS" };
+    const formData: CacheEntry = { manufacturer: "ASOS" };
     cache.update(id, formData);
 
-    const updatedFormData: BeaconCacheEntry = { model: "TROUSERS" };
+    const updatedFormData: CacheEntry = { model: "TROUSERS" };
     cache.update(id, updatedFormData);
 
     expect(cache.get(id)).toStrictEqual({
@@ -64,10 +64,10 @@ describe("FormCache", () => {
   });
 
   it("should update the overriding form field and add additional fields", () => {
-    const formData: BeaconCacheEntry = { manufacturer: "ASOS" };
+    const formData: CacheEntry = { manufacturer: "ASOS" };
     cache.update(id, formData);
 
-    const updatedFormData: BeaconCacheEntry = {
+    const updatedFormData: CacheEntry = {
       manufacturer: "TOPSHOP",
       model: "TROUSERS",
     };

--- a/test/lib/handlePageRequest.test.ts
+++ b/test/lib/handlePageRequest.test.ts
@@ -4,7 +4,9 @@ import { handlePageRequest } from "../../src/lib/handlePageRequest";
 
 jest.mock("../../src/lib/middleware", () => ({
   __esModule: true,
-  updateFormCache: jest.fn().mockReturnValue({}),
+  parseFormData: jest.fn().mockReturnValue({}),
+  updateFormCache: jest.fn(),
+  getCache: jest.fn().mockReturnValue({}),
   withCookieRedirect: jest.fn().mockImplementation((callback) => {
     return async (context) => {
       return callback(context);
@@ -38,10 +40,6 @@ describe("handlePageRequest()", () => {
     });
   });
 
-  xit("should return a props object with errors on invalid form submission", () => {
-    // TODO
-  });
-
   it("should return a props object when receives a GET request", async () => {
     const mockUserAccessedPageWithGETRequest = {
       req: {
@@ -59,5 +57,9 @@ describe("handlePageRequest()", () => {
         needsValidation: false,
       },
     });
+  });
+
+  xit("should return a props object with errors on invalid form submission", () => {
+    // TODO
   });
 });

--- a/test/lib/handlePageRequest.test.ts
+++ b/test/lib/handlePageRequest.test.ts
@@ -38,6 +38,10 @@ describe("handlePageRequest()", () => {
     });
   });
 
+  xit("should return a props object with errors on invalid form submission", () => {
+    // TODO
+  });
+
   it("should return a props object when receives a GET request", async () => {
     const mockUserAccessedPageWithGETRequest = {
       req: {

--- a/test/lib/handlePageRequest.test.ts
+++ b/test/lib/handlePageRequest.test.ts
@@ -1,0 +1,59 @@
+// Mock module dependencies in getServerSideProps for testing handlePageRequest()
+import { GetServerSidePropsContext } from "next";
+import { handlePageRequest } from "../../src/lib/handlePageRequest";
+
+jest.mock("../../src/lib/middleware", () => ({
+  __esModule: true,
+  updateFormCache: jest.fn().mockReturnValue({}),
+  withCookieRedirect: jest.fn().mockImplementation((callback) => {
+    return async (context) => {
+      return callback(context);
+    };
+  }),
+}));
+jest.mock("../../src/lib/formValidator", () => ({
+  __esModule: true,
+  FormValidator: {
+    hasErrors: jest.fn().mockReturnValue(false),
+  },
+}));
+
+describe("handlePageRequest()", () => {
+  it("should redirect user to given next page on valid form submission", async () => {
+    const mockUserSubmittedFormContext = {
+      req: {
+        method: "POST",
+      },
+    };
+    const nextPagePath = "/page-to-redirect-to-if-form-data-is-valid";
+    const response = await handlePageRequest(nextPagePath)(
+      mockUserSubmittedFormContext as GetServerSidePropsContext
+    );
+
+    expect(response).toStrictEqual({
+      redirect: {
+        statusCode: 303,
+        destination: nextPagePath,
+      },
+    });
+  });
+
+  it("should return a props object when receives a GET request", async () => {
+    const mockUserAccessedPageWithGETRequest = {
+      req: {
+        method: "GET",
+      },
+    };
+    const nextPagePath = "/irrelevant";
+    const response = await handlePageRequest(nextPagePath)(
+      mockUserAccessedPageWithGETRequest as GetServerSidePropsContext
+    );
+
+    expect(response).toStrictEqual({
+      props: {
+        formData: {},
+        needsValidation: false,
+      },
+    });
+  });
+});

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,26 +1,4 @@
-import { GetServerSidePropsContext } from "next";
-import {
-  ensureFormDataHasKeys,
-  handleFormSubmission,
-  toArray,
-} from "../../src/lib/utils";
-
-// Mock module dependencies in getServerSideProps for testing handleFormSubmission()
-jest.mock("../../src/lib/middleware", () => ({
-  __esModule: true,
-  updateFormCache: jest.fn().mockReturnValue({}),
-  withCookieRedirect: jest.fn().mockImplementation((callback) => {
-    return async (context) => {
-      return callback(context);
-    };
-  }),
-}));
-jest.mock("../../src/lib/formValidator", () => ({
-  __esModule: true,
-  FormValidator: {
-    hasErrors: jest.fn().mockReturnValue(false),
-  },
-}));
+import { ensureFormDataHasKeys, toArray } from "../../src/lib/utils";
 
 describe("toArray()", () => {
   it("should convert a number to an array", () => {
@@ -69,45 +47,5 @@ describe("ensureFormDataHasKeys()", () => {
     ensureFormDataHasKeys(input, ...requiredKeys);
 
     expect(input).toEqual(expectedInput);
-  });
-});
-
-describe("handleFormSubmission()", () => {
-  it("should redirect user to given next page on valid form submission", async () => {
-    const mockUserSubmittedFormContext = {
-      req: {
-        method: "POST",
-      },
-    };
-    const nextPagePath = "/page-to-redirect-to-if-form-data-is-valid";
-    const response = await handleFormSubmission(nextPagePath)(
-      mockUserSubmittedFormContext as GetServerSidePropsContext
-    );
-
-    expect(response).toStrictEqual({
-      redirect: {
-        statusCode: 303,
-        destination: nextPagePath,
-      },
-    });
-  });
-
-  it("should return a props object when receives a GET request", async () => {
-    const mockUserAccessedPageWithGETRequest = {
-      req: {
-        method: "GET",
-      },
-    };
-    const nextPagePath = "/irrelevant";
-    const response = await handleFormSubmission(nextPagePath)(
-      mockUserAccessedPageWithGETRequest as GetServerSidePropsContext
-    );
-
-    expect(response).toStrictEqual({
-      props: {
-        formData: {},
-        needsValidation: false,
-      },
-    });
   });
 });

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,4 +1,26 @@
-import { ensureFormDataHasKeys, toArray } from "../../src/lib/utils";
+import { GetServerSidePropsContext } from "next";
+import {
+  ensureFormDataHasKeys,
+  handleFormSubmission,
+  toArray,
+} from "../../src/lib/utils";
+
+// Mock module dependencies in getServerSideProps for testing handleFormSubmission()
+jest.mock("../../src/lib/middleware", () => ({
+  __esModule: true,
+  updateFormCache: jest.fn().mockReturnValue({}),
+  withCookieRedirect: jest.fn().mockImplementation((callback) => {
+    return async (context) => {
+      return callback(context);
+    };
+  }),
+}));
+jest.mock("../../src/lib/formValidator", () => ({
+  __esModule: true,
+  FormValidator: {
+    hasErrors: jest.fn().mockReturnValue(false),
+  },
+}));
 
 describe("toArray()", () => {
   it("should convert a number to an array", () => {
@@ -47,5 +69,45 @@ describe("ensureFormDataHasKeys()", () => {
     ensureFormDataHasKeys(input, ...requiredKeys);
 
     expect(input).toEqual(expectedInput);
+  });
+});
+
+describe("handleFormSubmission()", () => {
+  it("should redirect user to given next page on valid form submission", async () => {
+    const mockUserSubmittedFormContext = {
+      req: {
+        method: "POST",
+      },
+    };
+    const nextPagePath = "/page-to-redirect-to-if-form-data-is-valid";
+    const response = await handleFormSubmission(nextPagePath)(
+      mockUserSubmittedFormContext as GetServerSidePropsContext
+    );
+
+    expect(response).toStrictEqual({
+      redirect: {
+        statusCode: 303,
+        destination: nextPagePath,
+      },
+    });
+  });
+
+  it("should return a props object when receives a GET request", async () => {
+    const mockUserAccessedPageWithGETRequest = {
+      req: {
+        method: "GET",
+      },
+    };
+    const nextPagePath = "/irrelevant";
+    const response = await handleFormSubmission(nextPagePath)(
+      mockUserAccessedPageWithGETRequest as GetServerSidePropsContext
+    );
+
+    expect(response).toStrictEqual({
+      props: {
+        formData: {},
+        needsValidation: false,
+      },
+    });
   });
 });

--- a/test/pages/register-a-beacon/beacon-information.test.tsx
+++ b/test/pages/register-a-beacon/beacon-information.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import BeaconInformationPage from "../../../src/pages/register-a-beacon/beacon-information";
-import PrimaryBeaconUse from "../../../src/pages/register-a-beacon/primary-beacon-use";
 
 describe("BeaconInformationPage", () => {
   it("should have a back button which directs the user to the check beacon details page", () => {
@@ -14,13 +13,11 @@ describe("BeaconInformationPage", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const result = render(<PrimaryBeaconUse />);
+    const result = render(<BeaconInformationPage />);
+    const ownPath = "/register-a-beacon/beacon-information";
 
     const form = result.container.querySelector("form");
 
-    expect(form).toHaveAttribute(
-      "action",
-      "/register-a-beacon/beacon-information"
-    );
+    expect(form).toHaveAttribute("action", ownPath);
   });
 });

--- a/test/pages/register-a-beacon/beacon-information.test.tsx
+++ b/test/pages/register-a-beacon/beacon-information.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import BeaconInformationPage from "../../../src/pages/register-a-beacon/beacon-information";
+import PrimaryBeaconUse from "../../../src/pages/register-a-beacon/primary-beacon-use";
 
 describe("BeaconInformationPage", () => {
   it("should have a back button which directs the user to the check beacon details page", () => {
@@ -9,6 +10,17 @@ describe("BeaconInformationPage", () => {
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
       "/register-a-beacon/check-beacon-details"
+    );
+  });
+
+  it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
+    const result = render(<PrimaryBeaconUse />);
+
+    const form = result.container.querySelector("form");
+
+    expect(form).toHaveAttribute(
+      "action",
+      "/register-a-beacon/beacon-information"
     );
   });
 });

--- a/test/pages/register-a-beacon/beacon-information.test.tsx
+++ b/test/pages/register-a-beacon/beacon-information.test.tsx
@@ -13,10 +13,10 @@ describe("BeaconInformationPage", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const result = render(<BeaconInformationPage />);
+    const { container } = render(<BeaconInformationPage />);
     const ownPath = "/register-a-beacon/beacon-information";
 
-    const form = result.container.querySelector("form");
+    const form = container.querySelector("form");
 
     expect(form).toHaveAttribute("action", ownPath);
   });

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -15,6 +15,17 @@ describe("PrimaryBeaconUse", () => {
     );
   });
 
+  it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
+    const result = render(<PrimaryBeaconUse />);
+    const ownPath = "/register-a-beacon/primary-beacon-use";
+
+    const form = result.container.querySelector("form");
+
+    expect(form).toHaveAttribute("action", ownPath);
+  });
+
+  it("should redirect to about-the-vessel page on successful form submission", () => {});
+
   describe("getServerSideProps()", () => {
     let context;
     beforeEach(() => {

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { GetServerSidePropsContext } from "next";
 import React from "react";
-import { handleFormSubmission } from "../../../src/lib/utils";
+import { handlePageRequest } from "../../../src/lib/handlePageRequest";
 import PrimaryBeaconUse, {
   getServerSideProps,
 } from "../../../src/pages/register-a-beacon/primary-beacon-use";
 
-jest.mock("../../../src/lib/utils", () => ({
+jest.mock("../../../src/lib/handlePageRequest", () => ({
   __esModule: true,
-  handleFormSubmission: jest.fn().mockImplementation(() => jest.fn()),
+  handlePageRequest: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
 describe("PrimaryBeaconUse", () => {
@@ -34,7 +34,7 @@ describe("PrimaryBeaconUse", () => {
     const dummyContext = {};
     await getServerSideProps(dummyContext as GetServerSidePropsContext);
 
-    expect(handleFormSubmission).toHaveBeenCalledWith(
+    expect(handlePageRequest).toHaveBeenCalledWith(
       "/register-a-beacon/about-the-vessel"
     );
   });

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -13,7 +13,7 @@ jest.mock("../../../src/lib/handlePageRequest", () => ({
 
 describe("PrimaryBeaconUse", () => {
   it("should have a back button which directs the user to the beacon information page", () => {
-    render(<PrimaryBeaconUse />);
+    render(<PrimaryBeaconUse formData={{}} needsValidation={false} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
@@ -22,7 +22,9 @@ describe("PrimaryBeaconUse", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const result = render(<PrimaryBeaconUse />);
+    const result = render(
+      <PrimaryBeaconUse formData={{}} needsValidation={false} />
+    );
     const ownPath = "/register-a-beacon/primary-beacon-use";
 
     const form = result.container.querySelector("form");
@@ -35,7 +37,8 @@ describe("PrimaryBeaconUse", () => {
     await getServerSideProps(dummyContext as GetServerSidePropsContext);
 
     expect(handlePageRequest).toHaveBeenCalledWith(
-      "/register-a-beacon/about-the-vessel"
+      "/register-a-beacon/about-the-vessel",
+      expect.anything()
     );
   });
 });

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
 import React from "react";
 import { formSubmissionCookieId } from "../../../src/lib/types";
 import PrimaryBeaconUse, {
@@ -49,7 +50,7 @@ describe("PrimaryBeaconUse", () => {
     };
 
     const response = await getServerSideProps(
-      mockUserSubmittedFormContext as any
+      mockUserSubmittedFormContext as GetServerSidePropsContext
     );
 
     expect(response).toStrictEqual({

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,26 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { GetServerSidePropsContext } from "next";
 import React from "react";
-import { formSubmissionCookieId } from "../../../src/lib/types";
+import { handleFormSubmission } from "../../../src/lib/utils";
 import PrimaryBeaconUse, {
   getServerSideProps,
 } from "../../../src/pages/register-a-beacon/primary-beacon-use";
 
-// Mock module dependencies in getServerSideProps
-jest.mock("../../../src/lib/middleware", () => ({
+jest.mock("../../../src/lib/utils", () => ({
   __esModule: true,
-  updateFormCache: jest.fn().mockReturnValue({}),
-  withCookieRedirect: jest.fn().mockImplementation((callback) => {
-    return async (context) => {
-      return callback(context);
-    };
-  }),
-}));
-jest.mock("../../../src/lib/formValidator", () => ({
-  __esModule: true,
-  FormValidator: {
-    hasErrors: jest.fn().mockReturnValue(false),
-  },
+  handleFormSubmission: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
 describe("PrimaryBeaconUse", () => {
@@ -43,39 +31,11 @@ describe("PrimaryBeaconUse", () => {
   });
 
   it("should redirect to about-the-vessel page on valid form submission", async () => {
-    const mockUserSubmittedFormContext = {
-      req: {
-        method: "POST",
-      },
-    };
+    const dummyContext = {};
+    await getServerSideProps(dummyContext as GetServerSidePropsContext);
 
-    const response = await getServerSideProps(
-      mockUserSubmittedFormContext as GetServerSidePropsContext
+    expect(handleFormSubmission).toHaveBeenCalledWith(
+      "/register-a-beacon/about-the-vessel"
     );
-
-    expect(response).toStrictEqual({
-      redirect: {
-        statusCode: 303,
-        destination: "/register-a-beacon/about-the-vessel",
-      },
-    });
-  });
-
-  xdescribe("getServerSideProps()", () => {
-    let context;
-    beforeEach(() => {
-      context = {
-        req: {
-          cookies: {
-            [formSubmissionCookieId]: "1",
-          },
-        },
-      };
-    });
-
-    it("should return an empty props object", async () => {
-      const expectedProps = await getServerSideProps(context);
-      expect(expectedProps).toStrictEqual({ props: {} });
-    });
   });
 });

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,24 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { FormValidator } from "../../../src/lib/formValidator";
-import {
-  updateFormCache,
-  withCookieRedirect,
-} from "../../../src/lib/middleware";
 import { formSubmissionCookieId } from "../../../src/lib/types";
 import PrimaryBeaconUse, {
   getServerSideProps,
 } from "../../../src/pages/register-a-beacon/primary-beacon-use";
 
+// Mock module dependencies in getServerSideProps
 jest.mock("../../../src/lib/middleware", () => ({
-  // updateFormCache: jest.fn(),
-  withCookieRedirect: jest
-    .fn()
-    .mockImplementation((callback) => async () => callback({})),
+  __esModule: true,
+  updateFormCache: jest.fn().mockReturnValue({}),
+  withCookieRedirect: jest.fn().mockImplementation((callback) => {
+    return async (context) => {
+      return callback(context);
+    };
+  }),
 }));
-
-const mockUpdateFormCache = updateFormCache as jest.Mock;
-const mockWithCookieRedirect = withCookieRedirect as jest.Mock;
+jest.mock("../../../src/lib/formValidator", () => ({
+  __esModule: true,
+  FormValidator: {
+    hasErrors: jest.fn().mockReturnValue(false),
+  },
+}));
 
 describe("PrimaryBeaconUse", () => {
   it("should have a back button which directs the user to the beacon information page", () => {
@@ -40,38 +42,14 @@ describe("PrimaryBeaconUse", () => {
   });
 
   it("should redirect to about-the-vessel page on valid form submission", async () => {
-    jest.mock("../../../src/lib/formValidator");
-
-    FormValidator.hasErrors = jest.fn().mockReturnValue(false);
-
-    // TODO: Don't use require() syntax
-    const MockReq = require("mock-req");
-    const req = new MockReq({
-      method: "POST",
-    });
-
-    const mockUserSubmittedFormContext = () => {
-      return {
-        req: req,
-        cookies: {
-          [formSubmissionCookieId]: "1",
-        },
-      };
+    const mockUserSubmittedFormContext = {
+      req: {
+        method: "POST",
+      },
     };
 
-    // mockWithCookieRedirect.mockReturnValue("a value");
-
-    // mockWithCookieRedirect.mockImplementation((callback) => {
-    //   return "a value";
-    //   // async () => callback(mockUserSubmittedFormContext());
-    // });
-
-    // mockUpdateFormCache.mockReturnValue({});
-
-    console.log(getServerSideProps);
-
     const response = await getServerSideProps(
-      mockUserSubmittedFormContext() as any
+      mockUserSubmittedFormContext as any
     );
 
     expect(response).toStrictEqual({

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -22,19 +22,19 @@ describe("PrimaryBeaconUse", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const result = render(
+    const { container } = render(
       <PrimaryBeaconUse formData={{}} needsValidation={false} />
     );
     const ownPath = "/register-a-beacon/primary-beacon-use";
 
-    const form = result.container.querySelector("form");
+    const form = container.querySelector("form");
 
     expect(form).toHaveAttribute("action", ownPath);
   });
 
   it("should redirect to about-the-vessel page on valid form submission", async () => {
-    const dummyContext = {};
-    await getServerSideProps(dummyContext as GetServerSidePropsContext);
+    const context = {};
+    await getServerSideProps(context as GetServerSidePropsContext);
 
     expect(handlePageRequest).toHaveBeenCalledWith(
       "/register-a-beacon/about-the-vessel",


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

***With exception of conditional form validation*** (see Things to check), completes the `primary-beacon-use` page.

![image](https://user-images.githubusercontent.com/54271433/109035898-fcae1e80-76c0-11eb-9a7f-fe71b210266b.png)


## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Link form validation in to `primary-beacon-use` page.
- Abstract away complexity / reduce duplication from each page's `getServerSideProps()` function to `handlePageRequest.ts`.
- Generalise the caching functions to handle both `Beacon` and `Vessel` types.
- Create `transformFormData()` function, useful for when what is `POST`ed by the form is missing data, for example because a radio button isn't selected.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

https://trello.com/c/3KJGfjD9
https://miro.com/app/board/o9J_lZuM9qs=/?moveToWidget=3074457354391195351&cot=14

## Things to check

- Conditional formatting of the `input` field within the "Other pleasure vessel" radio is not done to limit the size of this PR.  User can submit a blank field:

![image](https://user-images.githubusercontent.com/54271433/109035155-40545880-76c0-11eb-8374-57a7f4e52e5a.png)

Intend to work on this next.

- Check out the [pattern for testing](test/pages/register-a-beacon/primary-beacon-use.test.tsx) `Page A` redirects to `Page B`.