### PR TITLE
Add tests for checking hex id is hexadecimal and 15 characters in length

### DIFF
--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -14,7 +14,7 @@ export interface FieldRule {
 }
 
 export abstract class FieldValidator implements IFieldValidator {
-  protected _rules: FieldRule[] = [];
+  protected _rules: FieldRule[];
 
   validate(value: string): IFieldValidationResponse {
     return {

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -14,7 +14,7 @@ export interface FieldRule {
 }
 
 export abstract class FieldValidator implements IFieldValidator {
-  protected _rules: FieldRule[];
+  protected _rules: FieldRule[] = [];
 
   validate(value: string): IFieldValidationResponse {
     return {
@@ -66,13 +66,17 @@ export class BeaconManufacturerValidator extends FieldValidator {
 }
 
 export class BeaconHexIdValidator extends FieldValidator {
+  private readonly errorMessagePrefix: string = "Beacon HEX ID or UIN must";
   constructor() {
     super();
     this._rules = [
       {
-        errorMessage:
-          "Beacon HEX ID or UIN must be 15 characters long and use numbers 0 to 9 and letters A to F",
-        predicateFn: (value) => value.match(/^[a-f0-9]{15}$/i) === null,
+        errorMessage: `${this.errorMessagePrefix} be 15 characters long`,
+        predicateFn: (value) => value.length !== 15,
+      },
+      {
+        errorMessage: `${this.errorMessagePrefix} use numbers 0 to 9 and letters A to F`,
+        predicateFn: (value) => value.match(/^[a-f0-9]+$/i) === null,
       },
     ];
   }

--- a/src/lib/fieldValidators.ts
+++ b/src/lib/fieldValidators.ts
@@ -72,7 +72,7 @@ export class BeaconHexIdValidator extends FieldValidator {
       {
         errorMessage:
           "Beacon HEX ID or UIN must be 15 characters long and use numbers 0 to 9 and letters A to F",
-        predicateFn: (value) => value.length !== 15,
+        predicateFn: (value) => value.match(/^[a-f0-9]{15}$/i) === null,
       },
     ];
   }

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -82,6 +82,10 @@ describe("BeaconHexIdValidator", () => {
       assertHasErrors("", 2);
     });
 
+    it("should have errors if not hexidecmal and not 15 characters in length", () => {
+      assertHasErrors("AR2", 2);
+    });
+
     it("should have an error if the value is shorter than 15 characters", () => {
       assertHasErrors("123456879", 1);
     });

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -64,14 +64,17 @@ describe("BeaconHexIdValidator", () => {
       beaconHexIdValidator = new BeaconHexIdValidator();
     });
 
-    const assertHasErrors = (value: string, numberOfErrors: number): void => {
+    const assertHasErrorsForValue = (
+      value: string,
+      numberOfErrors: number
+    ): void => {
       const validationResponse = beaconHexIdValidator.validate(value);
 
       expect(validationResponse.valid).toBe(false);
       expect(validationResponse.errorMessages.length).toBe(numberOfErrors);
     };
 
-    const assertNoErrors = (value: string): void => {
+    const assertNoErrorsForValue = (value: string): void => {
       const validationResponse = beaconHexIdValidator.validate(value);
 
       expect(validationResponse.valid).toBe(true);
@@ -79,39 +82,39 @@ describe("BeaconHexIdValidator", () => {
     };
 
     it("should have errors if no value provided", () => {
-      assertHasErrors("", 2);
+      assertHasErrorsForValue("", 2);
     });
 
     it("should have errors if not hexidecmal and not 15 characters in length", () => {
-      assertHasErrors("AR2", 2);
+      assertHasErrorsForValue("AR2", 2);
     });
 
     it("should have an error if the value is shorter than 15 characters", () => {
-      assertHasErrors("123456879", 1);
+      assertHasErrorsForValue("123456879", 1);
     });
 
     it("should have an error if the value contains non hex characters but is 15 characters long", () => {
-      assertHasErrors("0a1b2c3d4e5fa6x", 1);
+      assertHasErrorsForValue("0a1b2c3d4e5fa6x", 1);
     });
 
     it("should have an error if the value is longer than 15 characters", () => {
-      assertHasErrors("0123456789123456789", 1);
+      assertHasErrorsForValue("0123456789123456789", 1);
     });
 
     it("should return true if only 15 numbers", () => {
-      assertNoErrors("123456789123456");
+      assertNoErrorsForValue("123456789123456");
     });
 
     it("should not have any errors if it is only non-number 15 hex characters", () => {
-      assertNoErrors("abcdefabcdefabc");
+      assertNoErrorsForValue("abcdefabcdefabc");
     });
 
     it("should not have any errors if 15 hex characters", () => {
-      assertNoErrors("0a1b2c3d4e5fa6b");
+      assertNoErrorsForValue("0a1b2c3d4e5fa6b");
     });
 
     it("should ignore casing of hex characters", () => {
-      assertNoErrors("ABCDeFabCDefABc");
+      assertNoErrorsForValue("ABCDeFabCDefABc");
     });
   });
 });

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -64,11 +64,11 @@ describe("BeaconHexIdValidator", () => {
       beaconHexIdValidator = new BeaconHexIdValidator();
     });
 
-    const assertHasErrors = (value: string): void => {
+    const assertHasErrors = (value: string, numberOfErrors: number): void => {
       const validationResponse = beaconHexIdValidator.validate(value);
 
       expect(validationResponse.valid).toBe(false);
-      expect(validationResponse.errorMessages.length).toBe(1);
+      expect(validationResponse.errorMessages.length).toBe(numberOfErrors);
     };
 
     const assertNoErrors = (value: string): void => {
@@ -78,20 +78,20 @@ describe("BeaconHexIdValidator", () => {
       expect(validationResponse.errorMessages.length).toBe(0);
     };
 
-    it("should have an error if no value provided", () => {
-      assertHasErrors("");
+    it("should have errors if no value provided", () => {
+      assertHasErrors("", 2);
     });
 
     it("should have an error if the value is shorter than 15 characters", () => {
-      assertHasErrors("123456879");
+      assertHasErrors("123456879", 1);
     });
 
     it("should have an error if the value contains non hex characters but is 15 characters long", () => {
-      assertHasErrors("0a1b2c3d4e5fa6x");
+      assertHasErrors("0a1b2c3d4e5fa6x", 1);
     });
 
     it("should have an error if the value is longer than 15 characters", () => {
-      assertHasErrors("0123456789123456789");
+      assertHasErrors("0123456789123456789", 1);
     });
 
     it("should return true if only 15 numbers", () => {

--- a/test/lib/fieldValidators.test.ts
+++ b/test/lib/fieldValidators.test.ts
@@ -58,44 +58,56 @@ describe("BeaconManufacturerValidator", () => {
 
 describe("BeaconHexIdValidator", () => {
   describe("validate", () => {
-    it("should return false if value is empty string", () => {
-      const beaconHexIdValidator = new BeaconHexIdValidator();
-      const invalidValue = "";
+    let beaconHexIdValidator;
 
-      const validationResponse = beaconHexIdValidator.validate(invalidValue);
+    beforeEach(() => {
+      beaconHexIdValidator = new BeaconHexIdValidator();
+    });
+
+    const assertHasErrors = (value: string): void => {
+      const validationResponse = beaconHexIdValidator.validate(value);
 
       expect(validationResponse.valid).toBe(false);
       expect(validationResponse.errorMessages.length).toBe(1);
-    });
+    };
 
-    it("should return false if value is shorter than 15 characters", () => {
-      const beaconHexIdValidator = new BeaconHexIdValidator();
-      const invalidValue = "notquite15char";
-
-      const validationResponse = beaconHexIdValidator.validate(invalidValue);
-
-      expect(validationResponse.valid).toBe(false);
-      expect(validationResponse.errorMessages.length).toBe(1);
-    });
-
-    it("should return false if value is longer than 15 characters", () => {
-      const beaconHexIdValidator = new BeaconHexIdValidator();
-      const invalidValue = "bitlongerthanfifteencharacters";
-
-      const validationResponse = beaconHexIdValidator.validate(invalidValue);
-
-      expect(validationResponse.valid).toBe(false);
-      expect(validationResponse.errorMessages.length).toBe(1);
-    });
-
-    it("should return true otherwise", () => {
-      const beaconHexIdValidator = new BeaconHexIdValidator();
-      const validValue = "exactly15charac";
-
-      const validationResponse = beaconHexIdValidator.validate(validValue);
+    const assertNoErrors = (value: string): void => {
+      const validationResponse = beaconHexIdValidator.validate(value);
 
       expect(validationResponse.valid).toBe(true);
       expect(validationResponse.errorMessages.length).toBe(0);
+    };
+
+    it("should have an error if no value provided", () => {
+      assertHasErrors("");
+    });
+
+    it("should have an error if the value is shorter than 15 characters", () => {
+      assertHasErrors("123456879");
+    });
+
+    it("should have an error if the value contains non hex characters but is 15 characters long", () => {
+      assertHasErrors("0a1b2c3d4e5fa6x");
+    });
+
+    it("should have an error if the value is longer than 15 characters", () => {
+      assertHasErrors("0123456789123456789");
+    });
+
+    it("should return true if only 15 numbers", () => {
+      assertNoErrors("123456789123456");
+    });
+
+    it("should not have any errors if it is only non-number 15 hex characters", () => {
+      assertNoErrors("abcdefabcdefabc");
+    });
+
+    it("should not have any errors if 15 hex characters", () => {
+      assertNoErrors("0a1b2c3d4e5fa6b");
+    });
+
+    it("should ignore casing of hex characters", () => {
+      assertNoErrors("ABCDeFabCDefABc");
     });
   });
 });


### PR DESCRIPTION
## Context

- The wireframes checks whether the Hex ID is a 15 characters long and hex (0-9,a-f)
- I have confirmed with Konrad that it would be best to separate out these two errors messages
- Updated the validator function and added additional tests around this

## Changes in this pull request

- Should see two errors for the hex id if it is not 15 characters and not hex characters


Not 15 characters long, but is only hex characters
![image](https://user-images.githubusercontent.com/76042279/108874340-f9009600-75f3-11eb-8eff-f67a96d311f8.png)

Not 15 characters long and is not only hex characters
![image](https://user-images.githubusercontent.com/76042279/108874385-04ec5800-75f4-11eb-94e0-0a5f4b150873.png)

Is 15 characters long but not just hex characters
![image](https://user-images.githubusercontent.com/76042279/108874440-0fa6ed00-75f4-11eb-820e-7481004a9552.png)

Valid hex id
![image](https://user-images.githubusercontent.com/76042279/108874488-1a618200-75f4-11eb-9dcd-c3555310a937.png)


## Trello Links

- https://trello.com/c/q0SRN6Tn/254-validate-hex-id-is-15-characters-long-and-0-9-a-f-case-insensitive