### PR TITLE
Add error messages as an input into the form group

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, PropsWithChildren, ReactNode } from "react";
 import { HttpMethod } from "../lib/types";
+import { FieldErrorList } from "./ErrorSummary";
 
 interface FormProps {
   action: string;
@@ -16,6 +17,7 @@ interface FormGroupProps {
   children: ReactNode;
   className?: string;
   showErrors?: boolean;
+  errorMessages?: string[];
 }
 
 interface FormLabelProps {
@@ -53,11 +55,18 @@ export const FormGroup: FunctionComponent<FormGroupProps> = ({
   children,
   className = "",
   showErrors = false,
+  errorMessages = [],
 }: FormGroupProps): JSX.Element => {
   const errorClassName: string = showErrors ? "govuk-form-group--error" : "";
 
+  let errorsComponent: ReactNode;
+  if (showErrors) {
+    errorsComponent = <FieldErrorList errorMessages={errorMessages} />;
+  }
+
   return (
     <div className={`govuk-form-group ${className} ${errorClassName}`}>
+      {errorsComponent}
       {children}
     </div>
   );

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -7,10 +7,7 @@ import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import { Details } from "../../components/Details";
-import {
-  FieldErrorList,
-  FormErrorSummary,
-} from "../../components/ErrorSummary";
+import { FormErrorSummary } from "../../components/ErrorSummary";
 import {
   Form,
   FormFieldset,
@@ -110,8 +107,7 @@ const BeaconManufacturerInput: FunctionComponent<FormInputProps> = ({
   showErrors,
   errorMessages,
 }: FormInputProps): JSX.Element => (
-  <FormGroup showErrors={showErrors}>
-    {showErrors && <FieldErrorList errorMessages={errorMessages} />}
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
     <Input
       id="manufacturer"
       label="Enter your beacon manufacturer"
@@ -125,8 +121,7 @@ const BeaconModelInput: FunctionComponent<FormInputProps> = ({
   showErrors,
   errorMessages,
 }: FormInputProps): JSX.Element => (
-  <FormGroup showErrors={showErrors}>
-    {showErrors && <FieldErrorList errorMessages={errorMessages} />}
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
     <Input id="model" label="Enter your beacon model" defaultValue={value} />
   </FormGroup>
 );
@@ -136,8 +131,7 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
   showErrors,
   errorMessages,
 }: FormInputProps): JSX.Element => (
-  <FormGroup showErrors={showErrors}>
-    {showErrors && <FieldErrorList errorMessages={errorMessages} />}
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
     <Input
       id="hexId"
       label="Enter the 15 character beacon HEX ID or UIN number"

--- a/test/components/Form.test.tsx
+++ b/test/components/Form.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { FormLabel } from "../../src/components/Form";
+import { FormGroup, FormLabel } from "../../src/components/Form";
 
 describe("Form Components", () => {
   describe("FormLabel", () => {
@@ -15,6 +15,36 @@ describe("Form Components", () => {
         </>
       );
       expect(screen.getByLabelText(label)).toBeDefined();
+    });
+  });
+
+  describe("FormGroup", () => {
+    let errorMessage;
+    let errorMessages: string[];
+
+    beforeEach(() => {
+      errorMessage = "A Hex ID should be 15 characters long";
+      errorMessages = [errorMessage];
+    });
+
+    it("should display the error messages if errors and showErrors is true", () => {
+      render(
+        <FormGroup showErrors={true} errorMessages={errorMessages}>
+          <p>Hello world!</p>
+        </FormGroup>
+      );
+
+      expect(screen.getByText(errorMessage)).toBeDefined();
+    });
+
+    it("should not display the error messages if errors but showErrors is false", () => {
+      render(
+        <FormGroup showErrors={false} errorMessages={errorMessages}>
+          <p>Hello world!</p>
+        </FormGroup>
+      );
+
+      expect(screen.queryByText(errorMessage)).toBeNull();
     });
   });
 });

--- a/test/components/Form.test.tsx
+++ b/test/components/Form.test.tsx
@@ -33,7 +33,6 @@ describe("Form Components", () => {
           <p>Hello world!</p>
         </FormGroup>
       );
-
       expect(screen.getByText(errorMessage)).toBeDefined();
     });
 
@@ -43,7 +42,6 @@ describe("Form Components", () => {
           <p>Hello world!</p>
         </FormGroup>
       );
-
       expect(screen.queryByText(errorMessage)).toBeNull();
     });
   });


### PR DESCRIPTION
## Context

- Adds an optional input param to the `FormGroup` to allow consumers to set the error messages
- This is conditionally rendered based on whether `showErrors` is true

## Changes in this pull request

- Uplift current way of displaying errors in the `check-beacon-details` page

## Guidance to review

- I have checked that the errors are still displayed correctly in the current form for the `check-beacon-details` page