### PR TITLE
Emergency contact

### DIFF
--- a/src/lib/field-validators/emergencyContactFieldValidators.ts
+++ b/src/lib/field-validators/emergencyContactFieldValidators.ts
@@ -1,0 +1,30 @@
+import { FieldValidator } from "../fieldValidator";
+
+export class FullNameValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Emergency Contact Full name is a required field",
+        predicateFn: (value) => value.length === 0,
+      },
+    ];
+  }
+}
+
+export class TelephoneValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Emergency Contact Telephone is a required field",
+        predicateFn: (value) => value.length === 0,
+      },
+    ];
+  }
+}
+
+export const emergencyContactFieldValidatorLookup = {
+  emergencyContact1FullName: new FullNameValidator(),
+  emergencyContact1TelephoneNumber: new TelephoneValidator(),
+};

--- a/src/lib/field-validators/index.ts
+++ b/src/lib/field-validators/index.ts
@@ -1,6 +1,7 @@
 import { FieldValidator } from "../fieldValidator";
 import { MaritimePleasureVessel } from "../types";
 import { beaconFieldValidatorLookup } from "./beaconFieldValidators";
+import { emergencyContactFieldValidatorLookup } from "./emergencyContactFieldValidators";
 import { ownerFieldValidatorLookup } from "./ownerFieldValidators";
 import { vesselFieldValidatorLookup } from "./vesselFieldValidators";
 
@@ -57,4 +58,5 @@ export const fieldValidatorLookup = {
   otherPleasureVesselText: new OtherPleasureVesselTextValidator(),
   ...vesselFieldValidatorLookup,
   ...ownerFieldValidatorLookup,
+  ...emergencyContactFieldValidatorLookup,
 };

--- a/src/lib/field-validators/ownerFieldValidators.ts
+++ b/src/lib/field-validators/ownerFieldValidators.ts
@@ -24,6 +24,18 @@ export class TownOrCityValidator extends FieldValidator {
   }
 }
 
+export class FullNameValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Full name is a required field",
+        predicateFn: (value) => value.length === 0,
+      },
+    ];
+  }
+}
+
 export class PostcodeValidator extends FieldValidator {
   constructor() {
     super();
@@ -48,8 +60,27 @@ const isPostcodeValid = (postcode) => {
   return postcode.match(postcodeRegex);
 };
 
+export class EmailValidator extends FieldValidator {
+  constructor() {
+    super();
+    this._rules = [
+      {
+        errorMessage: "Email must be valid",
+        predicateFn: (value) => value.length > 0 && !isEmailValid(value),
+      },
+    ];
+  }
+}
+
+const isEmailValid = (email) => {
+  const emailRegex = /^[^\s@]+@([^\s@.,]+\.)+[^\s@.,]{2,}$/;
+  return email.match(emailRegex);
+};
+
 export const ownerFieldValidatorLookup = {
   beaconOwnerAddressLine1: new AddressLine1Validator(),
   beaconOwnerTownOrCity: new TownOrCityValidator(),
   beaconOwnerPostcode: new PostcodeValidator(),
+  beaconOwnerEmail: new EmailValidator(),
+  beaconOwnerFullName: new FullNameValidator(),
 };

--- a/src/lib/formCache.ts
+++ b/src/lib/formCache.ts
@@ -1,12 +1,17 @@
 import {
   Beacon,
   BeaconIntent,
+  EmergencyContacts,
   Owner,
   Vessel,
   VesselCommunications,
 } from "./types";
 
-type BeaconModel = Beacon & Owner & Vessel & VesselCommunications;
+type BeaconModel = Beacon &
+  Owner &
+  Vessel &
+  VesselCommunications &
+  EmergencyContacts;
 
 // Convenience type
 export type CacheEntry = Partial<BeaconModel> & {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,8 +48,12 @@ export interface Vessel {
 }
 
 export interface Owner {
+  beaconOwnerFullName: string;
+  beaconOwnerEmail?: string;
+  beaconOwnerTelephoneNumber?: string;
+  beaconOwnerAlternativeTelephoneNumber?: string;
   beaconOwnerAddressLine1: string;
-  beaconOwnerAddressLine2?: string;
+  beaconOwnerAddressLine2: string;
   beaconOwnerTownOrCity: string;
   beaconOwnerCounty?: string;
   beaconOwnerPostcode: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,4 +73,16 @@ export interface VesselCommunications {
   mobileTelephoneInput2: string;
 }
 
+export interface EmergencyContacts {
+  emergencyContact1FullName: string;
+  emergencyContact1TelephoneNumber: string;
+  emergencyContact1AlternativeTelephoneNumber: string;
+  emergencyContact2FullName: string;
+  emergencyContact2TelephoneNumber: string;
+  emergencyContact2AlternativeTelephoneNumber: string;
+  emergencyContact3FullName: string;
+  emergencyContact3TelephoneNumber: string;
+  emergencyContact3AlternativeTelephoneNumber: string;
+}
+
 export const formSubmissionCookieId = "submissionId";

--- a/src/pages/register-a-beacon/about-beacon-owner.tsx
+++ b/src/pages/register-a-beacon/about-beacon-owner.tsx
@@ -1,0 +1,148 @@
+import { GetServerSideProps } from "next";
+import React, { FunctionComponent } from "react";
+import { BackButton, Button } from "../../components/Button";
+import { FormErrorSummary } from "../../components/ErrorSummary";
+import {
+  Form,
+  FormFieldset,
+  FormGroup,
+  FormLegendPageHeading,
+} from "../../components/Form";
+import { Grid } from "../../components/Grid";
+import { FormInputProps, Input } from "../../components/Input";
+import { Layout } from "../../components/Layout";
+import { IfYouNeedHelp } from "../../components/Mca";
+import { FormValidator } from "../../lib/formValidator";
+import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
+import { ensureFormDataHasKeys } from "../../lib/utils";
+
+const AboutBeaconOwner: FunctionComponent<FormPageProps> = ({
+  formData,
+  needsValidation,
+}: FormPageProps): JSX.Element => {
+  formData = ensureFormDataHasKeys(
+    formData,
+    "beaconOwnerFullName",
+    "beaconOwnerTelephoneNumber",
+    "beaconOwnerAlternativeTelephoneNumber",
+    "beaconOwnerEmail"
+  );
+  const pageHeading = "About the beacon owner";
+  const errors = FormValidator.errorSummary(formData);
+  const { beaconOwnerFullName, beaconOwnerEmail } = FormValidator.validate(
+    formData
+  );
+  const pageHasErrors = needsValidation && FormValidator.hasErrors(formData);
+
+  return (
+    <>
+      <Layout
+        navigation={
+          <BackButton href="/register-a-beacon/more-vessel-details" />
+        }
+        title={pageHeading}
+        pageHasErrors={pageHasErrors}
+      >
+        <Grid
+          mainContent={
+            <>
+              <Form action="/register-a-beacon/about-beacon-owner">
+                <FormFieldset>
+                  <FormErrorSummary
+                    showErrorSummary={needsValidation}
+                    errors={errors}
+                  />
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
+
+                  <FullName
+                    value={formData.beaconOwnerFullName}
+                    showErrors={pageHasErrors && beaconOwnerFullName.invalid}
+                    errorMessages={beaconOwnerFullName.errorMessages}
+                  />
+
+                  <TelephoneNumber
+                    value={formData.beaconOwnerTelephoneNumber}
+                  />
+
+                  <AlternativeTelephoneNumber
+                    value={formData.beaconOwnerAlternativeTelephoneNumber}
+                  />
+
+                  <EmailAddress
+                    value={formData.beaconOwnerTownOrCity}
+                    showErrors={pageHasErrors && beaconOwnerEmail.invalid}
+                    errorMessages={beaconOwnerEmail.errorMessages}
+                  />
+                </FormFieldset>
+                <Button buttonText="Continue" />
+              </Form>
+              <IfYouNeedHelp />
+            </>
+          }
+        />
+      </Layout>
+    </>
+  );
+};
+
+const FullName: FunctionComponent<FormInputProps> = ({
+  value = "",
+  showErrors,
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
+    <Input id="beaconOwnerFullName" label="Full name" defaultValue={value} />
+  </FormGroup>
+);
+
+const TelephoneNumber: FunctionComponent<FormInputProps> = ({
+  value = "",
+  showErrors,
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
+    <Input
+      id="beaconOwnerTelephoneNumber"
+      label="Telephone number (optional)"
+      hintText="This can be a mobile or landline. For international numbers include the country code."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const AlternativeTelephoneNumber: FunctionComponent<FormInputProps> = ({
+  value = "",
+  showErrors,
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
+    <Input
+      id="beaconOwnerAlternativeTelephoneNumber"
+      label="Additional telephone number (optional)"
+      hintText="This can be a mobile or landline. For international numbers include the country code."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const EmailAddress: FunctionComponent<FormInputProps> = ({
+  value = "",
+  showErrors,
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
+    <Input
+      id="beaconOwnerEmail"
+      label="Email address (optional)"
+      hintText="You will receive an email confirming your beacon registration application, including a reference
+        number if you need to get in touch with the beacons registry team."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/beacon-owner-address"
+);
+
+export default AboutBeaconOwner;

--- a/src/pages/register-a-beacon/beacon-owner-address.tsx
+++ b/src/pages/register-a-beacon/beacon-owner-address.tsx
@@ -150,8 +150,6 @@ const PostcodeInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
-export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/emergency-contact"
-);
+export const getServerSideProps: GetServerSideProps = handlePageRequest("/");
 
 export default BeaconOwnerAddressPage;

--- a/src/pages/register-a-beacon/beacon-owner-address.tsx
+++ b/src/pages/register-a-beacon/beacon-owner-address.tsx
@@ -150,6 +150,8 @@ const PostcodeInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
-export const getServerSideProps: GetServerSideProps = handlePageRequest("/");
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/emergency-contact"
+);
 
 export default BeaconOwnerAddressPage;

--- a/src/pages/register-a-beacon/emergency-contact.tsx
+++ b/src/pages/register-a-beacon/emergency-contact.tsx
@@ -1,0 +1,192 @@
+import { GetServerSideProps } from "next";
+import React, { FunctionComponent } from "react";
+import { BackButton, Button } from "../../components/Button";
+import { FormErrorSummary } from "../../components/ErrorSummary";
+import {
+  Form,
+  FormFieldset,
+  FormGroup,
+  FormLegendPageHeading,
+} from "../../components/Form";
+import { Grid } from "../../components/Grid";
+import { Input } from "../../components/Input";
+import { InsetText } from "../../components/InsetText";
+import { Layout } from "../../components/Layout";
+import { IfYouNeedHelp } from "../../components/Mca";
+import { WarningText } from "../../components/WarningText";
+import { FormValidator } from "../../lib/formValidator";
+import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
+import { ensureFormDataHasKeys } from "../../lib/utils";
+
+export interface EmergencyContactGroupProps {
+  index: string;
+  fullName: string;
+  telephoneNumber: string;
+  alternativeTelephoneNumber: string;
+  fullNameErrorMessages?: string[];
+  fullNameErrors?: boolean;
+  telephoneNumberErrorMessages?: string[];
+  telephoneNumberErrors?: boolean;
+}
+
+const EmergencyContact: FunctionComponent<FormPageProps> = ({
+  formData,
+  needsValidation,
+}: FormPageProps): JSX.Element => {
+  formData = ensureFormDataHasKeys(
+    formData,
+    "emergencyContact1FullName",
+    "emergencyContact1TelephoneNumber",
+    "emergencyContact1AlternativeTelephoneNumber",
+    "emergencyContact2FullName",
+    "emergencyContact2TelephoneNumber",
+    "emergencyContact2AlternativeTelephoneNumber",
+    "emergencyContact3FullName",
+    "emergencyContact3TelephoneNumber",
+    "emergencyContact3AlternativeTelephoneNumber"
+  );
+  const pageHeading = "Add emergency contact information for up to 3 people";
+  const errors = FormValidator.errorSummary(formData);
+  const {
+    emergencyContact1FullName,
+    emergencyContact1TelephoneNumber,
+  } = FormValidator.validate(formData);
+  const pageHasErrors = needsValidation && FormValidator.hasErrors(formData);
+
+  return (
+    <>
+      <Layout
+        navigation={
+          <BackButton href="/register-a-beacon/beacon-owner-address" />
+        }
+        title={pageHeading}
+        pageHasErrors={pageHasErrors}
+      >
+        <Grid
+          mainContent={
+            <>
+              <Form action="/register-a-beacon/emergency-contact">
+                <FormFieldset>
+                  <FormErrorSummary
+                    showErrorSummary={needsValidation}
+                    errors={errors}
+                  />
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
+                  <InsetText>
+                    Your emergency contact information is vital for Search and
+                    Rescue. Provide as much detail as possible. Provide at least
+                    one contact.
+                  </InsetText>
+                  <WarningText>
+                    It is important that all your emergency contacts know the
+                    details of any trip you make, such as departure and expected
+                    arrival times, your planned route, how many persons you will
+                    be with and how to reach you in an emergency.
+                    <br />
+                    Only choose those people likely to know this information to
+                    be your emergency contact(s).
+                  </WarningText>
+
+                  <EmergencyContactGroup
+                    index="1"
+                    fullName={formData.emergencyContact1FullName}
+                    telephoneNumber={formData.emergencyContact1TelephoneNumber}
+                    alternativeTelephoneNumber={
+                      formData.emergencyContact1AlternativeTelephoneNumber
+                    }
+                    fullNameErrors={
+                      pageHasErrors && emergencyContact1FullName.invalid
+                    }
+                    fullNameErrorMessages={
+                      emergencyContact1FullName.errorMessages
+                    }
+                    telephoneNumberErrors={
+                      pageHasErrors && emergencyContact1TelephoneNumber.invalid
+                    }
+                    telephoneNumberErrorMessages={
+                      emergencyContact1TelephoneNumber.errorMessages
+                    }
+                  />
+
+                  <EmergencyContactGroup
+                    index="2"
+                    fullName={formData.emergencyContact1FullName}
+                    telephoneNumber={formData.emergencyContact1TelephoneNumber}
+                    alternativeTelephoneNumber={
+                      formData.emergencyContact1AlternativeTelephoneNumber
+                    }
+                  />
+
+                  <EmergencyContactGroup
+                    index="3"
+                    fullName={formData.emergencyContact1FullName}
+                    telephoneNumber={formData.emergencyContact1TelephoneNumber}
+                    alternativeTelephoneNumber={
+                      formData.emergencyContact1AlternativeTelephoneNumber
+                    }
+                  />
+                </FormFieldset>
+                <Button buttonText="Continue" />
+              </Form>
+              <IfYouNeedHelp />
+            </>
+          }
+        />
+      </Layout>
+    </>
+  );
+};
+
+const EmergencyContactGroup: FunctionComponent<EmergencyContactGroupProps> = ({
+  index = "",
+  fullName = "",
+  telephoneNumber = "",
+  alternativeTelephoneNumber = "",
+  fullNameErrors,
+  fullNameErrorMessages,
+  telephoneNumberErrors,
+  telephoneNumberErrorMessages,
+}: EmergencyContactGroupProps): JSX.Element => (
+  <>
+    <legend className="govuk-heading-m">
+      Emergency contact {index}
+      {index == "1" ? "" : " (optional)"}
+    </legend>
+    <FormGroup
+      showErrors={fullNameErrors}
+      errorMessages={fullNameErrorMessages}
+    >
+      <Input
+        id={"emergencyContact" + index + "FullName"}
+        label={
+          "Emergency contact's full name" + (index == "1" ? "" : " (optional)")
+        }
+        defaultValue={fullName}
+      />
+    </FormGroup>
+    <FormGroup
+      showErrors={telephoneNumberErrors}
+      errorMessages={telephoneNumberErrorMessages}
+    >
+      <Input
+        id={"emergencyContact" + index + "TelephoneNumber"}
+        label={
+          "Emergency contact's primary telephone number" +
+          (index == "1" ? "" : " (optional)")
+        }
+        defaultValue={telephoneNumber}
+      />
+    </FormGroup>
+    <FormGroup>
+      <Input
+        id={"emergencyContact" + index + "AlternativeTelephoneNumber"}
+        label="Emergency contact's secondary telephone number (optional)"
+        defaultValue={alternativeTelephoneNumber}
+      />
+    </FormGroup>
+  </>
+);
+
+export const getServerSideProps: GetServerSideProps = handlePageRequest("/");
+
+export default EmergencyContact;

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -118,7 +118,7 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
       return {
         redirect: {
           statusCode: 303,
-          destination: "/register-a-beacon/beacon-information",
+          destination: "/register-a-beacon/about-beacon-owner",
         },
       };
     }

--- a/test/pages/register-a-beacon/about-beacon-owner.test.tsx
+++ b/test/pages/register-a-beacon/about-beacon-owner.test.tsx
@@ -27,9 +27,11 @@ describe("AboutBeaconOwner", () => {
       };
     });
 
-    it("should return an empty props object", async () => {
+    it("should return a largely empty props object", async () => {
       const expectedProps = await getServerSideProps(context);
-      expect(expectedProps).toStrictEqual({ props: {} });
+      expect(expectedProps).toStrictEqual({
+        props: { formData: {}, needsValidation: false },
+      });
     });
   });
 });

--- a/test/pages/register-a-beacon/about-beacon-owner.test.tsx
+++ b/test/pages/register-a-beacon/about-beacon-owner.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { formSubmissionCookieId } from "../../../src/lib/types";
+import AboutBeaconOwner, {
+  getServerSideProps,
+} from "../../../src/pages/register-a-beacon/about-beacon-owner";
+
+describe("AboutBeaconOwner", () => {
+  it("should have a back button which directs the user to the primary beacon use page", () => {
+    render(<AboutBeaconOwner formData={{}} needsValidation={false} />);
+
+    expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
+      "href",
+      "/register-a-beacon/more-vessel-details"
+    );
+  });
+
+  describe("getServerSideProps()", () => {
+    let context;
+    beforeEach(() => {
+      context = {
+        req: {
+          cookies: {
+            [formSubmissionCookieId]: "1",
+          },
+        },
+      };
+    });
+
+    it("should return an empty props object", async () => {
+      const expectedProps = await getServerSideProps(context);
+      expect(expectedProps).toStrictEqual({ props: {} });
+    });
+  });
+});

--- a/test/pages/register-a-beacon/beacon-owner-address.test.tsx
+++ b/test/pages/register-a-beacon/beacon-owner-address.test.tsx
@@ -37,7 +37,7 @@ describe("BeaconOwnerAddressPage", () => {
     await getServerSideProps(context as GetServerSidePropsContext);
 
     // TODO update emergency contact page URL if different when page created
-    const startURL = "/";
+    const startURL = "/register-a-beacon/emergency-contact";
 
     expect(handlePageRequest).toHaveBeenCalledWith(startURL);
   });

--- a/test/pages/register-a-beacon/beacon-owner-address.test.tsx
+++ b/test/pages/register-a-beacon/beacon-owner-address.test.tsx
@@ -32,13 +32,13 @@ describe("BeaconOwnerAddressPage", () => {
     expect(form).toHaveAttribute("action", ownPath);
   });
 
-  it("should redirect to emergency contact page on valid form submission", async () => {
+  it("should redirect to the start page on valid form submission", async () => {
     const context = {};
     await getServerSideProps(context as GetServerSidePropsContext);
 
     // TODO update emergency contact page URL if different when page created
-    const emergencyContactPageURL = "/register-a-beacon/emergency-contact";
+    const startURL = "/";
 
-    expect(handlePageRequest).toHaveBeenCalledWith(emergencyContactPageURL);
+    expect(handlePageRequest).toHaveBeenCalledWith(startURL);
   });
 });

--- a/test/pages/register-a-beacon/emergency-contact.test.tsx
+++ b/test/pages/register-a-beacon/emergency-contact.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import React from "react";
+import { handlePageRequest } from "../../../src/lib/handlePageRequest";
+import AboutTheVessel, {
+  getServerSideProps,
+} from "../../../src/pages/register-a-beacon/emergency-contact";
+
+jest.mock("../../../src/lib/handlePageRequest", () => ({
+  __esModule: true,
+  handlePageRequest: jest.fn().mockImplementation(() => jest.fn()),
+}));
+
+describe("EmergencyContact", () => {
+  it("should have a back button which directs the user to the primary beacon use page", () => {
+    render(<AboutTheVessel formData={{}} needsValidation={false} />);
+
+    expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
+      "href",
+      "/register-a-beacon/beacon-owner-address"
+    );
+  });
+
+  it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
+    const { container } = render(
+      <AboutTheVessel formData={{}} needsValidation={false} />
+    );
+    const ownPath = "/register-a-beacon/emergency-contact";
+
+    const form = container.querySelector("form");
+
+    expect(form).toHaveAttribute("action", ownPath);
+  });
+
+  it("should redirect to the start page page on valid form submission", async () => {
+    const context = {};
+    await getServerSideProps(context as GetServerSidePropsContext);
+
+    expect(handlePageRequest).toHaveBeenCalledWith("/");
+  });
+});


### PR DESCRIPTION
## Context

A new emergency contact details page

## Changes in this pull request

- Creating the emergency contact page
- Creating caching mechanism thereof
- Creating validation thereof
- Hook it up from the beacon-owner-address page
<img width="692" alt="Screenshot 2021-02-25 at 19 13 50" src="https://user-images.githubusercontent.com/11423299/109207064-9ac4e600-77a0-11eb-9fed-1a2da4feb461.png">


## Guidance to review

Check it out! I wonder if the inset text is misused here and throughout: https://design-system.service.gov.uk/components/inset-text/

## Link to Trello card

https://trello.com/c/ooo36p8M/226-emergency-contact-information-page

## Things to check

- [x] Environment variables have been updated
