### PR TITLE
Refactor/form validation 4.0

### DIFF
--- a/src/components/ErrorSummary.tsx
+++ b/src/components/ErrorSummary.tsx
@@ -33,8 +33,8 @@ export const FormErrorSummary: FunctionComponent<FormErrorSummaryProps> = ({
         {errors.map((field) =>
           field.errorMessages.map((errorMessage, index) => (
             <FormErrorSummaryLink
-              key={`${field.fieldId}-${index}`}
-              href={`#${field.fieldId}`}
+              key={`${field.fieldName}-${index}`}
+              href={`#${field.fieldName}`}
               errorMessage={errorMessage}
             />
           ))

--- a/src/lib/field-validators/beaconFieldValidators.ts
+++ b/src/lib/field-validators/beaconFieldValidators.ts
@@ -6,7 +6,7 @@ export class BeaconModelValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Beacon model is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -18,7 +18,7 @@ export class BeaconManufacturerValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Beacon manufacturer is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -31,11 +31,11 @@ export class BeaconHexIdValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: `${this.errorMessagePrefix} be 15 characters long`,
-        predicateFn: (value) => value.length !== 15,
+        errorIf: (value) => value.length !== 15,
       },
       {
         errorMessage: `${this.errorMessagePrefix} use numbers 0 to 9 and letters A to F`,
-        predicateFn: (value) => value.match(/^[a-f0-9]+$/i) === null,
+        errorIf: (value) => value.match(/^[a-f0-9]+$/i) === null,
       },
     ];
   }

--- a/src/lib/field-validators/emergencyContactFieldValidators.ts
+++ b/src/lib/field-validators/emergencyContactFieldValidators.ts
@@ -6,7 +6,7 @@ export class FullNameValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Emergency Contact Full name is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -18,7 +18,7 @@ export class TelephoneValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Emergency Contact Telephone is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }

--- a/src/lib/field-validators/index.ts
+++ b/src/lib/field-validators/index.ts
@@ -11,11 +11,11 @@ export class MoreVesselDetailsValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Vessel details is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
       {
         errorMessage: "Vessel details must be less than 250 characters",
-        predicateFn: (value) => value.length > 250,
+        errorIf: (value) => value.length > 250,
       },
     ];
   }
@@ -27,12 +27,12 @@ export class MaritimePleasureVesselUseValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Maritime pleasure use is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
       {
         errorMessage:
           "Value is not a recognised type of maritime pleasure vessel",
-        predicateFn: (value) =>
+        errorIf: (value) =>
           value.length !== 0 &&
           !Object.values(MaritimePleasureVessel).includes(
             value as MaritimePleasureVessel
@@ -49,7 +49,7 @@ export class OtherPleasureVesselTextValidator extends FieldValidator {
       // TODO Conditional rule: if OtherPleasureVessel is selected, field is required
       // {
       //   errorMessage: "Other pleasure vessel text is a required field",
-      //   predicateFn: (value) => value.length === 0,
+      //   errorIf: (value) => value.length === 0,
       // },
     ];
   }

--- a/src/lib/field-validators/ownerFieldValidators.ts
+++ b/src/lib/field-validators/ownerFieldValidators.ts
@@ -6,7 +6,7 @@ export class AddressLine1Validator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Building number and street is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -18,7 +18,7 @@ export class TownOrCityValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Town or city is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -30,7 +30,7 @@ export class FullNameValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Full name is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
     ];
   }
@@ -42,11 +42,11 @@ export class PostcodeValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Postcode is required",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
       {
         errorMessage: "Postcode must be a valid UK postcode",
-        predicateFn: (value) => value.length > 0 && !isPostcodeValid(value),
+        errorIf: (value) => value.length > 0 && !isPostcodeValid(value),
       },
     ];
   }
@@ -66,7 +66,7 @@ export class EmailValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Email must be valid",
-        predicateFn: (value) => value.length > 0 && !isEmailValid(value),
+        errorIf: (value) => value.length > 0 && !isEmailValid(value),
       },
     ];
   }

--- a/src/lib/field-validators/vesselFieldValidators.ts
+++ b/src/lib/field-validators/vesselFieldValidators.ts
@@ -6,12 +6,12 @@ export class VesselMaxCapacityValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Maximum number of persons onboard is a required field",
-        predicateFn: (value) => value.length === 0,
+        errorIf: (value) => value.length === 0,
       },
       {
         errorMessage:
           "Maximum number of persons onboard must be a whole number",
-        predicateFn: (value) => value.match(/\D+/) !== null,
+        errorIf: (value) => value.match(/\D+/) !== null,
       },
     ];
   }
@@ -23,7 +23,7 @@ export class VesselAreaOfOperationValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Typical area of operation has too many characters",
-        predicateFn: (value) => value.length > 250,
+        errorIf: (value) => value.length > 250,
       },
     ];
   }
@@ -35,7 +35,7 @@ export class VesselBeaconLocationValidator extends FieldValidator {
     this._rules = [
       {
         errorMessage: "Where the beacon is kept has too many characters",
-        predicateFn: (value) => value.length > 100,
+        errorIf: (value) => value.length > 100,
       },
     ];
   }

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -1,4 +1,6 @@
-export interface IFieldValidator {
+import { IFieldRule } from "./validatorFunctions";
+
+export interface IClassBasedValidator {
   validate(value: string): IFieldValidationResponse;
 }
 
@@ -9,12 +11,7 @@ export interface IFieldValidationResponse {
   invalid: boolean;
 }
 
-export interface IFieldRule {
-  errorMessage: string;
-  errorIf: (valueToValidate: string) => boolean;
-}
-
-export abstract class FieldValidator implements IFieldValidator {
+export abstract class FieldValidator implements IClassBasedValidator {
   protected _rules: IFieldRule[];
 
   validate(value: string): IFieldValidationResponse {

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -11,7 +11,7 @@ export interface IFieldValidationResponse {
 
 export interface FieldRule {
   errorMessage: string;
-  predicateFn: (valueToValidate: string) => boolean;
+  errorIf: (valueToValidate: string) => boolean;
 }
 
 export abstract class FieldValidator implements IFieldValidator {
@@ -27,7 +27,7 @@ export abstract class FieldValidator implements IFieldValidator {
   }
 
   static valueViolatesRule(value: string, rule: FieldRule): boolean {
-    return rule.predicateFn(value);
+    return rule.errorIf(value);
   }
 
   private isValid(value: string): boolean {

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -9,13 +9,13 @@ export interface IFieldValidationResponse {
   invalid: boolean;
 }
 
-export interface FieldRule {
+export interface IFieldRule {
   errorMessage: string;
   errorIf: (valueToValidate: string) => boolean;
 }
 
 export abstract class FieldValidator implements IFieldValidator {
-  protected _rules: FieldRule[];
+  protected _rules: IFieldRule[];
 
   validate(value: string): IFieldValidationResponse {
     return {
@@ -26,7 +26,7 @@ export abstract class FieldValidator implements IFieldValidator {
     };
   }
 
-  static valueViolatesRule(value: string, rule: FieldRule): boolean {
+  static valueViolatesRule(value: string, rule: IFieldRule): boolean {
     return rule.errorIf(value);
   }
 

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -3,6 +3,7 @@ export interface IFieldValidator {
 }
 
 export interface IFieldValidationResponse {
+  value: string;
   errorMessages: string[];
   valid: boolean;
   invalid: boolean;
@@ -18,6 +19,7 @@ export abstract class FieldValidator implements IFieldValidator {
 
   validate(value: string): IFieldValidationResponse {
     return {
+      value: value,
       valid: this.isValid(value),
       invalid: !this.isValid(value),
       errorMessages: this.errorMessages(value),

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -1,16 +1,16 @@
 import { fieldValidatorLookup } from "./field-validators";
 import {
-  IFieldRule,
+  IClassBasedValidator,
   IFieldValidationResponse,
-  IFieldValidator,
 } from "./fieldValidator";
+import { IFunctionalValidator } from "./validatorFunctions";
 
 export interface IFormError {
   fieldName: string;
   errorMessages: string[];
 }
 
-export type Validator = IFieldValidator | IFieldRule[];
+export type Validator = Partial<IClassBasedValidator & IFunctionalValidator>;
 
 export class FormValidator {
   private static defaultResponseIfFieldNameNotInFormData: IFieldValidationResponse = {
@@ -78,7 +78,7 @@ export class FormValidator {
 
   private static validateField(
     // TODO: Change `any` for `IFieldRule[]` when type guard removed
-    validatorLookup: Record<string, any>,
+    validatorLookup: Record<string, Validator>,
     fieldName: string,
     value: string
   ) {
@@ -87,7 +87,7 @@ export class FormValidator {
       return { ...validatorLookup[fieldName].validate(value) };
     }
 
-    const rules = validatorLookup[fieldName];
+    const rules = validatorLookup[fieldName].rules;
 
     return {
       value: value,

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -4,6 +4,7 @@ import {
   GetServerSidePropsResult,
 } from "next";
 import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
+import { fieldValidatorLookup } from "./field-validators";
 import { CacheEntry } from "./formCache";
 import { FormValidator, Validator } from "./formValidator";
 import {
@@ -22,7 +23,7 @@ export interface FormPageProps {
 
 export const handlePageRequest = (
   destinationIfValid: string,
-  formRules: Record<string, Validator>,
+  formRules: Record<string, Validator> = fieldValidatorLookup,
   transformFunction: TransformFunction = (formData) => formData
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -4,9 +4,8 @@ import {
   GetServerSidePropsResult,
 } from "next";
 import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
-import { IFieldValidator } from "./fieldValidator";
 import { CacheEntry } from "./formCache";
-import { FormValidator } from "./formValidator";
+import { FormValidator, Validator } from "./formValidator";
 import {
   getCache,
   parseFormData,
@@ -23,7 +22,7 @@ export interface FormPageProps {
 
 export const handlePageRequest = (
   destinationIfValid: string,
-  formRules: Record<string, IFieldValidator>,
+  formRules: Record<string, Validator>,
   transformFunction: TransformFunction = (formData) => formData
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
@@ -56,7 +55,7 @@ export const handlePostRequest = async (
   context: GetServerSidePropsContext,
   destinationIfValid: string,
   transformFunction: TransformFunction = (formData) => formData,
-  formRules: Record<string, IFieldValidator>
+  formRules: Record<string, Validator>
 ): Promise<GetServerSidePropsResult<FormPageProps>> => {
   const transformedFormData = transformFunction(
     await parseFormData(context.req)

--- a/src/lib/validatorFunctions.ts
+++ b/src/lib/validatorFunctions.ts
@@ -2,6 +2,21 @@ export interface errorIf {
   (fieldValue: string): boolean;
 }
 
+export interface IFieldRule {
+  errorMessage: string;
+  errorIf: errorIf;
+}
+
+export interface IFunctionalValidator {
+  rules: IFieldRule[];
+  applyRulesIf?: IFieldCondition[];
+}
+
+export interface IFieldCondition {
+  fieldName: string;
+  meetsConditions: ((value: string) => boolean)[];
+}
+
 export const requiredFieldHasNoValue: errorIf = (value) => !value;
 
 export const isNot15CharactersLong: errorIf = (value) =>

--- a/src/lib/validatorFunctions.ts
+++ b/src/lib/validatorFunctions.ts
@@ -1,9 +1,11 @@
-export interface ValidatorFunction {
+export interface errorIf {
   (fieldValue: string): boolean;
 }
 
-export const emptyRequiredField: ValidatorFunction = (value) => !value;
+export const requiredInputHasNoValue: errorIf = (value) => value.length === 0;
 
-export const isNot15CharactersLong: ValidatorFunction = (value) => {
-  return !value || value.length !== 15;
-};
+export const isNot15CharactersLong: errorIf = (value) =>
+  !value || value.length !== 15;
+
+export const isNotHexadecimalString: errorIf = (value) =>
+  value.match(/^[a-f0-9]+$/i) === null;

--- a/src/lib/validatorFunctions.ts
+++ b/src/lib/validatorFunctions.ts
@@ -2,7 +2,7 @@ export interface errorIf {
   (fieldValue: string): boolean;
 }
 
-export const requiredInputHasNoValue: errorIf = (value) => value.length === 0;
+export const requiredFieldHasNoValue: errorIf = (value) => !value;
 
 export const isNot15CharactersLong: errorIf = (value) =>
   !value || value.length !== 15;

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -152,7 +152,8 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
 );
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/beacon-information"
+  "/register-a-beacon/beacon-information",
+  formRules
 );
 
 export default CheckBeaconDetails;

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -1,9 +1,4 @@
-import {
-  GetServerSideProps,
-  GetServerSidePropsContext,
-  GetServerSidePropsResult,
-} from "next";
-import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
+import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { BackButton, Button } from "../../components/Button";
 import { Details } from "../../components/Details";
@@ -21,12 +16,7 @@ import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
-import {
-  getCache,
-  parseFormData,
-  updateFormCache,
-  withCookieRedirect,
-} from "../../lib/middleware";
+import { handlePageRequest } from "../../lib/handlePageRequest";
 import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface CheckBeaconDetailsProps {
@@ -146,54 +136,8 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
-export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
-    if (context.req.method === "POST") {
-      return handlePostRequest(context);
-    } else {
-      return handleGetRequest(context.req.cookies);
-    }
-  }
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/beacon-information"
 );
-
-const handlePostRequest = async (
-  context: GetServerSidePropsContext
-): Promise<GetServerSidePropsResult<CheckBeaconDetailsProps>> => {
-  const rawFormData: CacheEntry = await parseFormData(context.req);
-  const formData: CacheEntry = {
-    ...rawFormData,
-    hexId: (rawFormData["hexId"] || "").toUpperCase(),
-  };
-
-  updateFormCache(context.req.cookies, formData);
-
-  const formIsValid = !FormValidator.hasErrors(formData);
-
-  if (formIsValid) {
-    return {
-      redirect: {
-        statusCode: 303,
-        destination: "/register-a-beacon/beacon-information",
-      },
-    };
-  }
-
-  return {
-    props: {
-      formData: formData,
-      needsValidation: true,
-    },
-  };
-};
-
-const handleGetRequest = (
-  cookies: NextApiRequestCookies
-): GetServerSidePropsResult<CheckBeaconDetailsProps> => {
-  return {
-    props: {
-      formData: getCache(cookies),
-    },
-  };
-};
 
 export default CheckBeaconDetails;

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -28,29 +28,35 @@ interface CheckBeaconDetailsProps {
 }
 
 const formRules = {
-  manufacturer: [
-    {
-      errorMessage: "Beacon manufacturer is a required field",
-      errorIf: requiredFieldHasNoValue,
-    },
-  ],
-  model: [
-    {
-      errorMessage: "Beacon model is a required field",
-      errorIf: requiredFieldHasNoValue,
-    },
-  ],
-  hexId: [
-    {
-      errorMessage: "Beacon HEX ID or UIN must be 15 characters long",
-      errorIf: isNot15CharactersLong,
-    },
-    {
-      errorMessage:
-        "Beacon HEX ID or UIN must use numbers 0 to 9 and letters A to F",
-      errorIf: isNotHexadecimalString,
-    },
-  ],
+  manufacturer: {
+    rules: [
+      {
+        errorMessage: "Beacon manufacturer is a required field",
+        errorIf: requiredFieldHasNoValue,
+      },
+    ],
+  },
+  model: {
+    rules: [
+      {
+        errorMessage: "Beacon model is a required field",
+        errorIf: requiredFieldHasNoValue,
+      },
+    ],
+  },
+  hexId: {
+    rules: [
+      {
+        errorMessage: "Beacon HEX ID or UIN must be 15 characters long",
+        errorIf: isNot15CharactersLong,
+      },
+      {
+        errorMessage:
+          "Beacon HEX ID or UIN must use numbers 0 to 9 and letters A to F",
+        errorIf: isNotHexadecimalString,
+      },
+    ],
+  },
 };
 
 const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -19,7 +19,7 @@ import { handlePageRequest } from "../../lib/handlePageRequest";
 import {
   isNot15CharactersLong,
   isNotHexadecimalString,
-  requiredInputHasNoValue,
+  requiredFieldHasNoValue,
 } from "../../lib/validatorFunctions";
 
 interface CheckBeaconDetailsProps {
@@ -31,13 +31,13 @@ const formRules = {
   manufacturer: [
     {
       errorMessage: "Beacon manufacturer is a required field",
-      errorIf: requiredInputHasNoValue,
+      errorIf: requiredFieldHasNoValue,
     },
   ],
   model: [
     {
       errorMessage: "Beacon model is a required field",
-      errorIf: requiredInputHasNoValue,
+      errorIf: requiredFieldHasNoValue,
     },
   ],
   hexId: [

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -16,36 +16,39 @@ import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
+import {
+  isNot15CharactersLong,
+  isNotHexadecimalString,
+  requiredInputHasNoValue,
+} from "../../lib/validatorFunctions";
 
 interface CheckBeaconDetailsProps {
   formData: Record<string, string>;
   needsValidation?: boolean;
 }
 
-const RequiredInputFieldHasNoValue = (value) => value.length === 0;
-
 const formRules = {
   manufacturer: [
     {
       errorMessage: "Beacon manufacturer is a required field",
-      errorIf: RequiredInputFieldHasNoValue,
+      errorIf: requiredInputHasNoValue,
     },
   ],
   model: [
     {
       errorMessage: "Beacon model is a required field",
-      errorIf: RequiredInputFieldHasNoValue,
+      errorIf: requiredInputHasNoValue,
     },
   ],
   hexId: [
     {
       errorMessage: "Beacon HEX ID or UIN must be 15 characters long",
-      errorIf: (value) => value.length !== 15,
+      errorIf: isNot15CharactersLong,
     },
     {
       errorMessage:
         "Beacon HEX ID or UIN must use numbers 0 to 9 and letters A to F",
-      errorIf: (value) => value.match(/^[a-f0-9]+$/i) === null,
+      errorIf: isNotHexadecimalString,
     },
   ],
 };

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -19,13 +19,11 @@ import {
   BeaconManufacturerValidator,
   BeaconModelValidator,
 } from "../../lib/field-validators/beaconFieldValidators";
-import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
-import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface CheckBeaconDetailsProps {
-  formData: CacheEntry;
+  formData: Record<string, string>;
   needsValidation?: boolean;
 }
 
@@ -33,25 +31,23 @@ const formRules = {
   manufacturer: new BeaconManufacturerValidator(),
   model: new BeaconModelValidator(),
   hexId: new BeaconHexIdValidator(),
+  newField: new BeaconModelValidator(),
 };
 
 const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
   formData,
   needsValidation = false,
 }: CheckBeaconDetailsProps): JSX.Element => {
-  formData = ensureFormDataHasKeys(formData, "manufacturer", "model", "hexId");
-
-  const errors = FormValidator.errorSummary(formData, formRules);
-
-  const { manufacturer, model, hexId } = FormValidator.validate(
-    formData,
-    formRules
-  );
-
   const pageHeading = "Check beacon details";
 
   const pageHasErrors =
     needsValidation && FormValidator.hasErrors(formData, formRules);
+  const errors = FormValidator.errorSummary(formData, formRules);
+
+  const { manufacturer, model, hexId, newField } = FormValidator.validate(
+    formData,
+    formRules
+  );
 
   return (
     <>
@@ -76,21 +72,27 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
                   </InsetText>
 
                   <BeaconManufacturerInput
-                    value={formData.manufacturer}
+                    value={manufacturer.value}
                     showErrors={needsValidation && manufacturer.invalid}
                     errorMessages={manufacturer.errorMessages}
                   />
 
                   <BeaconModelInput
-                    value={formData.model}
+                    value={model.value}
                     showErrors={needsValidation && model.invalid}
                     errorMessages={model.errorMessages}
                   />
 
                   <BeaconHexIdInput
-                    value={formData.hexId}
+                    value={hexId.value}
                     showErrors={needsValidation && hexId.invalid}
                     errorMessages={hexId.errorMessages}
+                  />
+
+                  <NewInput
+                    value={newField.value}
+                    showErrors={needsValidation && newField.invalid}
+                    errorMessages={newField.errorMessages}
                   />
                 </FormFieldset>
                 <Button buttonText="Continue" />
@@ -148,6 +150,21 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
     >
       TODO: Explain to users how to find their beacon HEX ID
     </Details>
+  </FormGroup>
+);
+
+const NewInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+  showErrors,
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
+    <Input
+      id="newField"
+      label="This is a totally new field with validation"
+      htmlAttributes={{ spellCheck: false }}
+      defaultValue={value}
+    />
   </FormGroup>
 );
 

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -14,11 +14,6 @@ import { FormInputProps, Input } from "../../components/Input";
 import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import {
-  BeaconHexIdValidator,
-  BeaconManufacturerValidator,
-  BeaconModelValidator,
-} from "../../lib/field-validators/beaconFieldValidators";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
 
@@ -27,11 +22,32 @@ interface CheckBeaconDetailsProps {
   needsValidation?: boolean;
 }
 
+const RequiredInputFieldHasNoValue = (value) => value.length === 0;
+
 const formRules = {
-  manufacturer: new BeaconManufacturerValidator(),
-  model: new BeaconModelValidator(),
-  hexId: new BeaconHexIdValidator(),
-  newField: new BeaconModelValidator(),
+  manufacturer: [
+    {
+      errorMessage: "Beacon manufacturer is a required field",
+      errorIf: RequiredInputFieldHasNoValue,
+    },
+  ],
+  model: [
+    {
+      errorMessage: "Beacon model is a required field",
+      errorIf: RequiredInputFieldHasNoValue,
+    },
+  ],
+  hexId: [
+    {
+      errorMessage: "Beacon HEX ID or UIN must be 15 characters long",
+      errorIf: (value) => value.length !== 15,
+    },
+    {
+      errorMessage:
+        "Beacon HEX ID or UIN must use numbers 0 to 9 and letters A to F",
+      errorIf: (value) => value.match(/^[a-f0-9]+$/i) === null,
+    },
+  ],
 };
 
 const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
@@ -44,7 +60,7 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
     needsValidation && FormValidator.hasErrors(formData, formRules);
   const errors = FormValidator.errorSummary(formData, formRules);
 
-  const { manufacturer, model, hexId, newField } = FormValidator.validate(
+  const { manufacturer, model, hexId } = FormValidator.validate(
     formData,
     formRules
   );
@@ -87,12 +103,6 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
                     value={hexId.value}
                     showErrors={needsValidation && hexId.invalid}
                     errorMessages={hexId.errorMessages}
-                  />
-
-                  <NewInput
-                    value={newField.value}
-                    showErrors={needsValidation && newField.invalid}
-                    errorMessages={newField.errorMessages}
                   />
                 </FormFieldset>
                 <Button buttonText="Continue" />
@@ -150,21 +160,6 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
     >
       TODO: Explain to users how to find their beacon HEX ID
     </Details>
-  </FormGroup>
-);
-
-const NewInput: FunctionComponent<FormInputProps> = ({
-  value = "",
-  showErrors,
-  errorMessages,
-}: FormInputProps): JSX.Element => (
-  <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
-    <Input
-      id="newField"
-      label="This is a totally new field with validation"
-      htmlAttributes={{ spellCheck: false }}
-      defaultValue={value}
-    />
   </FormGroup>
 );
 

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -14,6 +14,11 @@ import { FormInputProps, Input } from "../../components/Input";
 import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
+import {
+  BeaconHexIdValidator,
+  BeaconManufacturerValidator,
+  BeaconModelValidator,
+} from "../../lib/field-validators/beaconFieldValidators";
 import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
@@ -24,19 +29,29 @@ interface CheckBeaconDetailsProps {
   needsValidation?: boolean;
 }
 
+const formRules = {
+  manufacturer: new BeaconManufacturerValidator(),
+  model: new BeaconModelValidator(),
+  hexId: new BeaconHexIdValidator(),
+};
+
 const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
   formData,
   needsValidation = false,
 }: CheckBeaconDetailsProps): JSX.Element => {
   formData = ensureFormDataHasKeys(formData, "manufacturer", "model", "hexId");
 
-  const errors = FormValidator.errorSummary(formData);
+  const errors = FormValidator.errorSummary(formData, formRules);
 
-  const { manufacturer, model, hexId } = FormValidator.validate(formData);
+  const { manufacturer, model, hexId } = FormValidator.validate(
+    formData,
+    formRules
+  );
 
   const pageHeading = "Check beacon details";
 
-  const pageHasErrors = needsValidation && FormValidator.hasErrors(formData);
+  const pageHasErrors =
+    needsValidation && FormValidator.hasErrors(formData, formRules);
 
   return (
     <>

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -45,7 +45,8 @@ const formRules = {
     ],
     rules: [
       {
-        errorMessage: "Other pleasure vessel text is a required field",
+        errorMessage:
+          'More detail is required if "Other pleasure vessel" is selected',
         errorIf: (value) => value.length === 0,
       },
     ],

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -17,76 +17,56 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
-import { fieldValidatorLookup } from "../../lib/field-validators";
 import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
 import { MaritimePleasureVessel } from "../../lib/types";
-import { ensureFormDataHasKeys } from "../../lib/utils";
 
 interface PrimaryBeaconUseProps {
   formData: CacheEntry;
   needsValidation: boolean;
 }
 
-interface BeaconUseFormProps {
-  formData: CacheEntry;
-  checkedValue: string | null;
-  showErrors: boolean;
-  errorMessages: string[];
-}
+const formRules = {
+  maritimePleasureVesselUse: {
+    rules: [
+      {
+        errorMessage: "Maritime pleasure use is a required field",
+        errorIf: (value) => value.length === 0,
+      },
+    ],
+  },
+  otherPleasureVesselText: {
+    applyRulesIf: [
+      {
+        fieldName: "maritimePleasureVesselUse",
+        meetsConditions: [(value) => value === "OTHER"],
+      },
+    ],
+    rules: [
+      {
+        errorMessage: "Other pleasure vessel text is a required field",
+        errorIf: (value) => value.length === 0,
+      },
+    ],
+  },
+};
 
 const PrimaryBeaconUse: FunctionComponent<PrimaryBeaconUseProps> = ({
   formData,
   needsValidation = false,
 }: PrimaryBeaconUseProps): JSX.Element => {
-  formData = ensureFormDataHasKeys(
-    formData,
-    "maritimePleasureVesselUse",
-    "otherPleasureVesselText"
-  );
+  const pageHeading =
+    "What type of maritime pleasure vessel will you mostly use this beacon on?";
 
-  const errors = FormValidator.errorSummary(formData);
+  const {
+    maritimePleasureVesselUse,
+    otherPleasureVesselText,
+  } = FormValidator.validate(formData, formRules);
 
-  return (
-    <Layout
-      title={
-        "What type of maritime pleasure vessel will you mostly use this beacon on?"
-      }
-      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
-      pageHasErrors={errors.length > 0 && needsValidation}
-    >
-      <Grid
-        mainContent={
-          <>
-            <FormErrorSummary
-              errors={errors}
-              showErrorSummary={needsValidation}
-            />
-            <BeaconUseForm
-              checkedValue={formData.maritimePleasureVesselUse}
-              formData={formData}
-              showErrors={needsValidation && FormValidator.hasErrors(formData)}
-              errorMessages={
-                FormValidator.validate(formData).maritimePleasureVesselUse
-                  .errorMessages
-              }
-            />
+  const errors = FormValidator.errorSummary(formData, formRules);
+  const pageHasErrors = needsValidation && errors.length > 0;
 
-            <IfYouNeedHelp />
-          </>
-        }
-      />
-    </Layout>
-  );
-};
-
-const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
-  formData,
-  checkedValue = null,
-  showErrors,
-  errorMessages,
-}: BeaconUseFormProps): JSX.Element => {
   const setCheckedIfUserSelected = (userSelectedValue, componentValue) => {
     return {
       defaultChecked: userSelectedValue === componentValue,
@@ -94,95 +74,121 @@ const BeaconUseForm: FunctionComponent<BeaconUseFormProps> = ({
   };
 
   return (
-    <Form action="/register-a-beacon/primary-beacon-use">
-      <FormGroup showErrors={showErrors} errorMessages={errorMessages}>
-        <FormFieldset>
-          <FormLegendPageHeading>
-            What type of maritime pleasure vessel will you mostly use this
-            beacon on?
-          </FormLegendPageHeading>
-        </FormFieldset>
-        <RadioListConditional>
-          <RadioListItemHint
-            id="motor-vessel"
-            name="maritimePleasureVesselUse"
-            value={MaritimePleasureVessel.MOTOR}
-            hintText="E.g. Speedboat, RIB"
-            inputHtmlAttributes={setCheckedIfUserSelected(
-              checkedValue,
-              MaritimePleasureVessel.MOTOR
-            )}
-          >
-            Motor vessel
-          </RadioListItemHint>
-          <RadioListItemHint
-            id="sailing-vessel"
-            name="maritimePleasureVesselUse"
-            value={MaritimePleasureVessel.SAILING}
-            hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-            inputHtmlAttributes={setCheckedIfUserSelected(
-              checkedValue,
-              MaritimePleasureVessel.SAILING
-            )}
-          >
-            Sailing vessel
-          </RadioListItemHint>
-          <RadioListItemHint
-            id="rowing-vessel"
-            name="maritimePleasureVesselUse"
-            value={MaritimePleasureVessel.ROWING}
-            hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-            inputHtmlAttributes={setCheckedIfUserSelected(
-              checkedValue,
-              MaritimePleasureVessel.ROWING
-            )}
-          >
-            Rowing vessel
-          </RadioListItemHint>
-          <RadioListItemHint
-            id="small-unpowered-vessel"
-            name="maritimePleasureVesselUse"
-            value={MaritimePleasureVessel.SMALL_UNPOWERED}
-            hintText="E.g. Canoe, Kayak"
-            inputHtmlAttributes={setCheckedIfUserSelected(
-              checkedValue,
-              MaritimePleasureVessel.SMALL_UNPOWERED
-            )}
-          >
-            Small unpowered vessel
-          </RadioListItemHint>
-          <RadioListItemHint
-            id="other-pleasure-vessel"
-            name="maritimePleasureVesselUse"
-            value={MaritimePleasureVessel.OTHER}
-            hintText="E.g. Surfboard, Kitesurfing"
-            inputHtmlAttributes={{
-              ...{
-                "data-aria-controls": "conditional-other-pleasure-vessel",
-              },
-              ...setCheckedIfUserSelected(
-                checkedValue,
-                MaritimePleasureVessel.OTHER
-              ),
-            }}
-          >
-            Other pleasure vessel
-          </RadioListItemHint>
-          <RadioListItemConditional id="conditional-other-pleasure-vessel">
-            <FormGroup>
-              <Input
-                id="other-pleasure-vessel-text"
-                name="otherPleasureVesselText"
-                label="What sort of vessel is it?"
-                defaultValue={formData.otherPleasureVesselText}
-              />
-            </FormGroup>
-          </RadioListItemConditional>
-        </RadioListConditional>
-      </FormGroup>
+    <Layout
+      title={pageHeading}
+      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+      pageHasErrors={pageHasErrors}
+    >
+      <Grid
+        mainContent={
+          <>
+            <FormErrorSummary
+              errors={errors}
+              showErrorSummary={pageHasErrors}
+            />
+            <Form action="/register-a-beacon/primary-beacon-use">
+              <FormGroup
+                showErrors={pageHasErrors}
+                errorMessages={maritimePleasureVesselUse.errorMessages}
+              >
+                <FormFieldset>
+                  <FormLegendPageHeading>
+                    What type of maritime pleasure vessel will you mostly use
+                    this beacon on?
+                  </FormLegendPageHeading>
+                </FormFieldset>
+                <RadioListConditional>
+                  <RadioListItemHint
+                    id="motor-vessel"
+                    name="maritimePleasureVesselUse"
+                    value={MaritimePleasureVessel.MOTOR}
+                    hintText="E.g. Speedboat, RIB"
+                    inputHtmlAttributes={setCheckedIfUserSelected(
+                      maritimePleasureVesselUse.value,
+                      MaritimePleasureVessel.MOTOR
+                    )}
+                  >
+                    Motor vessel
+                  </RadioListItemHint>
+                  <RadioListItemHint
+                    id="sailing-vessel"
+                    name="maritimePleasureVesselUse"
+                    value={MaritimePleasureVessel.SAILING}
+                    hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+                    inputHtmlAttributes={setCheckedIfUserSelected(
+                      maritimePleasureVesselUse.value,
+                      MaritimePleasureVessel.SAILING
+                    )}
+                  >
+                    Sailing vessel
+                  </RadioListItemHint>
+                  <RadioListItemHint
+                    id="rowing-vessel"
+                    name="maritimePleasureVesselUse"
+                    value={MaritimePleasureVessel.ROWING}
+                    hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+                    inputHtmlAttributes={setCheckedIfUserSelected(
+                      maritimePleasureVesselUse.value,
+                      MaritimePleasureVessel.ROWING
+                    )}
+                  >
+                    Rowing vessel
+                  </RadioListItemHint>
+                  <RadioListItemHint
+                    id="small-unpowered-vessel"
+                    name="maritimePleasureVesselUse"
+                    value={MaritimePleasureVessel.SMALL_UNPOWERED}
+                    hintText="E.g. Canoe, Kayak"
+                    inputHtmlAttributes={setCheckedIfUserSelected(
+                      maritimePleasureVesselUse.value,
+                      MaritimePleasureVessel.SMALL_UNPOWERED
+                    )}
+                  >
+                    Small unpowered vessel
+                  </RadioListItemHint>
+                  <RadioListItemHint
+                    id="other-pleasure-vessel"
+                    name="maritimePleasureVesselUse"
+                    value={MaritimePleasureVessel.OTHER}
+                    hintText="E.g. Surfboard, Kitesurfing"
+                    inputHtmlAttributes={{
+                      ...{
+                        "data-aria-controls":
+                          "conditional-other-pleasure-vessel",
+                      },
+                      ...setCheckedIfUserSelected(
+                        maritimePleasureVesselUse.value,
+                        MaritimePleasureVessel.OTHER
+                      ),
+                    }}
+                  >
+                    Other pleasure vessel
+                  </RadioListItemHint>
+                  <RadioListItemConditional id="conditional-other-pleasure-vessel">
+                    <FormGroup
+                      showErrors={
+                        pageHasErrors && otherPleasureVesselText.invalid
+                      }
+                      errorMessages={otherPleasureVesselText.errorMessages}
+                    >
+                      <Input
+                        id="otherPleasureVesselText"
+                        label="What sort of vessel is it?"
+                        defaultValue={formData.otherPleasureVesselText}
+                      />
+                    </FormGroup>
+                  </RadioListItemConditional>
+                </RadioListConditional>
+              </FormGroup>
 
-      <Button buttonText="Continue" />
-    </Form>
+              <Button buttonText="Continue" />
+            </Form>
+
+            <IfYouNeedHelp />
+          </>
+        }
+      />
+    </Layout>
   );
 };
 
@@ -195,7 +201,7 @@ const ensureMaritimePleasureVesselUseIsSubmitted = (formData) => {
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
   "/register-a-beacon/about-the-vessel",
-  fieldValidatorLookup,
+  formRules,
   ensureMaritimePleasureVesselUseIsSubmitted
 );
 

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -17,6 +17,7 @@ import {
   RadioListItemConditional,
   RadioListItemHint,
 } from "../../components/RadioList";
+import { fieldValidatorLookup } from "../../lib/field-validators";
 import { CacheEntry } from "../../lib/formCache";
 import { FormValidator } from "../../lib/formValidator";
 import { handlePageRequest } from "../../lib/handlePageRequest";
@@ -194,6 +195,7 @@ const ensureMaritimePleasureVesselUseIsSubmitted = (formData) => {
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
   "/register-a-beacon/about-the-vessel",
+  fieldValidatorLookup,
   ensureMaritimePleasureVesselUseIsSubmitted
 );
 

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -28,9 +28,9 @@ const mockInvalidFieldValidator = (errors): IFieldValidator => {
 describe("FormValidator", () => {
   describe("validate", () => {
     it("should return a 'valid' response when the only field is valid", () => {
-      const formData = { testFieldId: "valid value" };
+      const formData = { testFieldName: "valid value" };
       const fieldValidatorLookup = {
-        testFieldId: mockValidFieldValidator(),
+        testFieldName: mockValidFieldValidator(),
       };
 
       const validationResponse = FormValidator.validate(
@@ -39,7 +39,7 @@ describe("FormValidator", () => {
       );
 
       expect(validationResponse).toEqual({
-        testFieldId: {
+        testFieldName: {
           valid: true,
           invalid: false,
           errorMessages: [],
@@ -48,9 +48,9 @@ describe("FormValidator", () => {
     });
 
     it("should return an 'invalid' response when the only field is invalid", () => {
-      const formData = { anotherTestFieldId: "invalid value" };
+      const formData = { anotherTestFieldName: "invalid value" };
       const fieldValidatorLookup = {
-        anotherTestFieldId: mockInvalidFieldValidator(["TooLong"]),
+        anotherTestFieldName: mockInvalidFieldValidator(["TooLong"]),
       };
 
       const validationResponse = FormValidator.validate(
@@ -59,7 +59,7 @@ describe("FormValidator", () => {
       );
 
       expect(validationResponse).toEqual({
-        anotherTestFieldId: {
+        anotherTestFieldName: {
           valid: false,
           invalid: true,
           errorMessages: ["TooLong"],
@@ -69,12 +69,12 @@ describe("FormValidator", () => {
 
     it("should return an 'invalid' response when one of two fields is invalid", () => {
       const formData = {
-        firstTestFieldId: "invalid value",
-        secondTestFieldId: "valid value",
+        firstTestFieldName: "invalid value",
+        secondTestFieldName: "valid value",
       };
       const fieldValidatorLookup = {
-        firstTestFieldId: mockInvalidFieldValidator(["Required"]),
-        secondTestFieldId: mockValidFieldValidator(),
+        firstTestFieldName: mockInvalidFieldValidator(["Required"]),
+        secondTestFieldName: mockValidFieldValidator(),
       };
 
       const validationResponse = FormValidator.validate(
@@ -83,12 +83,12 @@ describe("FormValidator", () => {
       );
 
       expect(validationResponse).toEqual({
-        firstTestFieldId: {
+        firstTestFieldName: {
           valid: false,
           invalid: true,
           errorMessages: ["Required"],
         },
-        secondTestFieldId: {
+        secondTestFieldName: {
           valid: true,
           invalid: false,
           errorMessages: [],
@@ -100,10 +100,10 @@ describe("FormValidator", () => {
   describe("errorSummary", () => {
     it("should return a blank errorMessage summary when the only field is valid", () => {
       const formData = {
-        validFieldId: "valid value",
+        validFieldName: "valid value",
       };
       const fieldValidatorLookup = {
-        validFieldId: mockValidFieldValidator(),
+        validFieldName: mockValidFieldValidator(),
       };
 
       const errorSummary = FormValidator.errorSummary(
@@ -116,10 +116,10 @@ describe("FormValidator", () => {
 
     it("should return a summary of one errorMessage when the only field is invalid", () => {
       const formData = {
-        invalidFieldId: "invalid value",
+        invalidFieldName: "invalid value",
       };
       const fieldValidatorLookup = {
-        invalidFieldId: mockInvalidFieldValidator(["TooLong"]),
+        invalidFieldName: mockInvalidFieldValidator(["TooLong"]),
       };
 
       const errorSummary = FormValidator.errorSummary(
@@ -128,20 +128,20 @@ describe("FormValidator", () => {
       );
 
       expect(errorSummary).toEqual([
-        { fieldId: "invalidFieldId", errorMessages: ["TooLong"] },
+        { fieldName: "invalidFieldName", errorMessages: ["TooLong"] },
       ]);
     });
 
     it("should return a summary of two errorMessages when two fields are invalid", () => {
       const formData = {
-        invalidFieldId1: "invalid value",
-        invalidFieldId2: "invalid value",
-        validFieldId: "valid value",
+        invalidFieldName1: "invalid value",
+        invalidFieldName2: "invalid value",
+        validFieldName: "valid value",
       };
       const fieldValidatorLookup = {
-        invalidFieldId1: mockInvalidFieldValidator(["TooLong"]),
-        invalidFieldId2: mockInvalidFieldValidator(["TooLong"]),
-        validFieldId: mockValidFieldValidator(),
+        invalidFieldName1: mockInvalidFieldValidator(["TooLong"]),
+        invalidFieldName2: mockInvalidFieldValidator(["TooLong"]),
+        validFieldName: mockValidFieldValidator(),
       };
 
       const errorSummary = FormValidator.errorSummary(
@@ -150,8 +150,8 @@ describe("FormValidator", () => {
       );
 
       expect(errorSummary).toEqual([
-        { fieldId: "invalidFieldId1", errorMessages: ["TooLong"] },
-        { fieldId: "invalidFieldId2", errorMessages: ["TooLong"] },
+        { fieldName: "invalidFieldName1", errorMessages: ["TooLong"] },
+        { fieldName: "invalidFieldName2", errorMessages: ["TooLong"] },
       ]);
     });
   });

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -173,7 +173,7 @@ describe("FormValidator", () => {
 
     describe("conditional validation", () => {
       it("should not validate textInput when radioButton condition is not met", () => {
-        const mockValidatorFn = jest.fn();
+        const mockInvalidValidatorFn = jest.fn().mockReturnValue(true);
         const formData = {
           radioButton: "MOTOR_VESSEL",
           textInput: "should not be validated because radioButton !== OTHER",
@@ -185,7 +185,7 @@ describe("FormValidator", () => {
               {
                 errorMessage:
                   "textInput is required if radioButton OTHER is selected",
-                errorIf: mockValidatorFn,
+                errorIf: mockInvalidValidatorFn,
               },
             ],
             applyRulesIf: [
@@ -198,12 +198,14 @@ describe("FormValidator", () => {
         };
 
         FormValidator.validate(formData, formRules);
+        const errorSummary = FormValidator.errorSummary(formData, formRules);
 
-        expect(mockValidatorFn).not.toBeCalled();
+        expect(mockInvalidValidatorFn).not.toBeCalled();
+        expect(errorSummary.length).toBe(0);
       });
 
       it("should validate textInput when radioButton condition is met", () => {
-        const mockValidatorFn = jest.fn();
+        const mockInvalidValidatorFn = jest.fn().mockReturnValue(true);
         const formData = {
           radioButton: "OTHER",
           textInput: "should be validated because radioButton === OTHER",
@@ -215,7 +217,7 @@ describe("FormValidator", () => {
               {
                 errorMessage:
                   "textInput is required if radioButton OTHER is selected",
-                errorIf: mockValidatorFn,
+                errorIf: mockInvalidValidatorFn,
               },
             ],
             applyRulesIf: [
@@ -228,8 +230,10 @@ describe("FormValidator", () => {
         };
 
         FormValidator.validate(formData, formRules);
+        const errorSummary = FormValidator.errorSummary(formData, formRules);
 
-        expect(mockValidatorFn).toBeCalled();
+        expect(mockInvalidValidatorFn).toBeCalled();
+        expect(errorSummary.length).toBe(1);
       });
     });
   });

--- a/test/lib/validatorFunction.test.ts
+++ b/test/lib/validatorFunction.test.ts
@@ -1,28 +1,28 @@
 import {
-  emptyRequiredField,
   isNot15CharactersLong,
+  requiredFieldHasNoValue,
 } from "../../src/lib/validatorFunctions";
 
 describe("emptyRequiredField", () => {
   it("should return true when field is an empty string", () => {
-    expect(emptyRequiredField("")).toBe(true);
+    expect(requiredFieldHasNoValue("")).toBe(true);
   });
 
   it("should return true when field is undefined", () => {
-    expect(emptyRequiredField(undefined)).toBe(true);
+    expect(requiredFieldHasNoValue(undefined)).toBe(true);
   });
 
   it("should return true when field is null", () => {
-    expect(emptyRequiredField(null)).toBe(true);
+    expect(requiredFieldHasNoValue(null)).toBe(true);
   });
 
   it("should return false when field is a string of one or more character", () => {
-    expect(emptyRequiredField("Space")).toBe(false);
-    expect(emptyRequiredField("Jam")).toBe(false);
+    expect(requiredFieldHasNoValue("Space")).toBe(false);
+    expect(requiredFieldHasNoValue("Jam")).toBe(false);
   });
 
   it("should return false when field is a string of a number", () => {
-    expect(emptyRequiredField("42")).toBe(false);
+    expect(requiredFieldHasNoValue("42")).toBe(false);
   });
 });
 

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -38,6 +38,7 @@ describe("PrimaryBeaconUse", () => {
 
     expect(handlePageRequest).toHaveBeenCalledWith(
       "/register-a-beacon/about-the-vessel",
+      expect.anything(),
       expect.anything()
     );
   });


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Currently, form validation is more complicated than it needs to be.  To create a new form page, the developer currently has to modify several files:
- The page itself
- Create a new `FieldValidator`
- Add it to the `fieldValidatorLookup`
- Add the field to the `CacheEntry` type

This PR aims to reduce the complexity by: 

-  Removing global/module dependencies
-  Shifting from class-based validators (the `FieldValidator` classes) to functional in the name of reducing boilerplate and promoting reusability.

Having reduced complexity, it makes a small change to add conditional validation with an optional field on the `formRule` object.

If this PR is merged, the developer only has to modify one file to create a new form / add a field to an existing form. 

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Replace dependency on global `fieldValidatorLookup` with injected object defined on the relevant page.
- Make field values pass through the `FormValidator`.  This is so data related to a form field comes from one place, improving readability and reducing the number of objects for which the developer needs to keep a mental model.  E.g.:
```jsx
<FieldComponent
     value={field.value}
     showErrors={needsValidation && field.invalid}
     errorMessages={field.errorMessages}
/>
```
- Extends `FormValidator` to be able to use functional validators in place of sub-classes of `FieldValidator`, e.g.:
```js
model: [
    {
      errorMessage: "Beacon model is a required field",
      errorIf: requiredFieldHasNoValue,
    },
  ],
``` 
- Uses a type guard to maintain "old" functionality of class-based `FieldValidator`s (and tests) while move to functional validation is made.
- Adds simple conditional validation.  See [primary-beacon-use.tsx](https://github.com/mcagov/beacons-webapp/blob/1119ae81b445b8e49e50a3dbcfdfcd3ad3b34507/src/pages/register-a-beacon/primary-beacon-use.tsx):

![image](https://user-images.githubusercontent.com/54271433/109383954-bbe12000-78e1-11eb-9b4f-22dcae86b590.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

[check-beacon-details](https://github.com/mcagov/beacons-webapp/blob/1119ae81b445b8e49e50a3dbcfdfcd3ad3b34507/src/pages/register-a-beacon/check-beacon-details.tsx) is the example of how form validation / construction would exist in one place, with re-used functional validators replaced class-based.
[primary-beacon-use.tsx](https://github.com/mcagov/beacons-webapp/blob/1119ae81b445b8e49e50a3dbcfdfcd3ad3b34507/src/pages/register-a-beacon/primary-beacon-use.tsx) is the example of conditional form validation, e.g. text field is required if radio button is selected.

I've used a [type guard](https://basarat.gitbook.io/typescript/type-system/typeguard) to allow `FormValidator` to use both the "old" class-based validators and the "new" functional validators.  If we go with this solution, I propose we aim to get rid of the type guard ASAP by removing class-based validators entirely.