### PR TITLE
Add cypress tests for primary beacon use

### DIFF
--- a/cypress/integration/common.spec.ts
+++ b/cypress/integration/common.spec.ts
@@ -1,4 +1,6 @@
 export const requiredFieldErrorMessage = "required field";
+export const tooManyCharactersErrorMessage = "too many characters";
+export const mustBeAnIntegerErrorMessage = "must be a whole number";
 
 export const andICanClickTheBackLinkToGoToPreviousPage = (
   previousPageURL: string
@@ -29,5 +31,9 @@ export const thenIShouldSeeAnErrorMessageThatContains = (
 };
 
 export const whenIType = (value: string, inputName: string): void => {
-  cy.get(`input[name="${inputName}"]`).type(value);
+  cy.get(`[name="${inputName}"]`).type(value);
+};
+
+export const givenIHaveSelected = (optionId: string): void => {
+  cy.get(optionId).click();
 };

--- a/cypress/integration/primaryBeaconUse.spec.ts
+++ b/cypress/integration/primaryBeaconUse.spec.ts
@@ -1,0 +1,47 @@
+import {
+  givenIHaveSelected,
+  requiredFieldErrorMessage,
+  thenIShouldSeeAnErrorMessageThatContains,
+  thenTheUrlShouldContain,
+  whenIClickContinue,
+  whenIType,
+} from "./common.spec";
+
+describe("As a beacon owner, I want to submit my primary beacon use", () => {
+  const pageLocation = "/register-a-beacon/primary-beacon-use";
+
+  beforeEach(() => {
+    givenIAmOnThePrimaryBeaconUsePage();
+  });
+
+  it("displays an error if no primary beacon use is selected", () => {
+    whenIClickContinue();
+    thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
+  });
+
+  it("routes to the next page if there are no errors with the selected primary beacon use", () => {
+    givenIHaveSelected("#motor-vessel");
+    whenIClickContinue();
+
+    thenTheUrlShouldContain("/register-a-beacon/about-the-vessel");
+  });
+
+  it("displays an error if 'Other pleasure vessel' is selected, but no text is provided", () => {
+    givenIHaveSelected("#other-pleasure-vessel");
+    whenIClickContinue();
+    thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
+  });
+
+  it("routes to the next page if there are no errors with Other pleasure vessel selected", () => {
+    givenIHaveSelected("#other-pleasure-vessel");
+    whenIType("Surfboard", "otherPleasureVesselText");
+    whenIClickContinue();
+
+    thenTheUrlShouldContain("/register-a-beacon/about-the-vessel");
+  });
+
+  const givenIAmOnThePrimaryBeaconUsePage = () => {
+    cy.visit("/");
+    cy.visit(pageLocation);
+  };
+});

--- a/cypress/integration/primaryBeaconUse.spec.ts
+++ b/cypress/integration/primaryBeaconUse.spec.ts
@@ -7,7 +7,7 @@ import {
   whenIType,
 } from "./common.spec";
 
-describe("As a beacon owner, I want to submit my primary beacon use", () => {
+describe("As a beacon owner, I want to submit the primary use for my beacon", () => {
   const pageLocation = "/register-a-beacon/primary-beacon-use";
 
   beforeEach(() => {

--- a/cypress/integration/vesselCommunications.spec.ts
+++ b/cypress/integration/vesselCommunications.spec.ts
@@ -1,4 +1,4 @@
-import { whenIClickContinue } from "./common.spec";
+import { givenIHaveSelected, whenIClickContinue } from "./common.spec";
 
 describe("As a beacon owner, I want to register my communication details so SAR can contact me in an emergency", () => {
   const pageUrl = "/register-a-beacon/vessel-communications";
@@ -8,7 +8,7 @@ describe("As a beacon owner, I want to register my communication details so SAR 
   });
 
   it("requires an MMSI number if the fixed VHF checkbox is selected", () => {
-    givenIHaveSelectedTheFixedVhfRadioOption();
+    givenIHaveSelected("#fixedVhfRadio");
     andIHaveLeftTheRelevantTextInputBlank();
 
     whenIClickContinue();
@@ -17,7 +17,7 @@ describe("As a beacon owner, I want to register my communication details so SAR 
   });
 
   it("requires an MMSI number if the portable VHF checkbox is selected", () => {
-    givenIHaveSelectedThePortableVhfRadioOption();
+    givenIHaveSelected("#portableVhfRadio");
     andIHaveLeftTheRelevantTextInputBlank();
 
     whenIClickContinue();
@@ -26,7 +26,7 @@ describe("As a beacon owner, I want to register my communication details so SAR 
   });
 
   it("requires a phone number if the satellite telephone checkbox is selected", () => {
-    givenIHaveSelectedTheSatelliteTelephoneOption();
+    givenIHaveSelected("#satelliteTelephone");
     andIHaveLeftTheRelevantTextInputBlank();
 
     whenIClickContinue();
@@ -34,8 +34,8 @@ describe("As a beacon owner, I want to register my communication details so SAR 
     thenISeeAnError();
   });
 
-  it("requires a phone number if the satellite telephone checkbox is selected", () => {
-    givenIHaveSelectedTheMobileTelephoneOption();
+  it("requires a phone number if the mobile telephone checkbox is selected", () => {
+    givenIHaveSelected("#mobileTelephone");
     andIHaveLeftTheRelevantTextInputBlank();
 
     whenIClickContinue();
@@ -46,19 +46,6 @@ describe("As a beacon owner, I want to register my communication details so SAR 
   const givenIAmOnTheVesselCommunicationsPage = () => {
     cy.visit("/"); // Sets cookie
     cy.visit(pageUrl);
-  };
-
-  const givenIHaveSelectedTheFixedVhfRadioOption = () =>
-    cy.get("#fixedVhfRadio").click();
-
-  const givenIHaveSelectedThePortableVhfRadioOption = () =>
-    cy.get("#portableVhfRadio").click();
-
-  const givenIHaveSelectedTheSatelliteTelephoneOption = () =>
-    cy.get("#satelliteTelephone").click();
-
-  const givenIHaveSelectedTheMobileTelephoneOption = () => {
-    cy.get("#mobileTelephone").click();
   };
 
   const andIHaveLeftTheRelevantTextInputBlank = () => null;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -148,7 +148,8 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
                       }
                     >
                       <Input
-                        id="otherPleasureVesselText"
+                        id="other-pleasure-vessel-text"
+                        name="otherPleasureVesselText"
                         label="What sort of vessel is it?"
                         defaultValue={form.fields.otherPleasureVesselText.value}
                       />

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -148,8 +148,7 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
                       }
                     >
                       <Input
-                        id="other-pleasure-vessel-text"
-                        name="otherPleasureVesselText"
+                        id="otherPleasureVesselText"
                         label="What sort of vessel is it?"
                         defaultValue={form.fields.otherPleasureVesselText.value}
                       />


### PR DESCRIPTION
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add cypress tests for `primary-beacon-use` page:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/32230328/110454595-55b58380-80bf-11eb-8e84-151c2ad457eb.png">

- Changed `whenIType` so it can be used on other text inputs - mainly TextArea

- Extracted `givenIHaveSelected` from the `vessel communications` page tests, so it can be more reusable ♻️ 

- On the `primary-beacon-use` page, made the current `id` (otherPleasureVesselText) the `name` and added a new `id` that's kebab-case to match our convention 🍡 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Please let me know if the tests look okay/valuable to you - or if there is anything else there that you'd like to test!

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/U7YwzUsE/282-set-up-functional-integration-tests-to-frontend