### PR TITLE
Add cypress tests for about-the-vessel page

### DIFF
--- a/cypress/integration/aboutTheVessel.spec.ts
+++ b/cypress/integration/aboutTheVessel.spec.ts
@@ -1,0 +1,63 @@
+import {
+  mustBeAnIntegerErrorMessage,
+  requiredFieldErrorMessage,
+  thenIShouldSeeAnErrorMessageThatContains,
+  thenTheUrlShouldContain,
+  tooManyCharactersErrorMessage,
+  whenIClickContinue,
+  whenIType,
+} from "./common.spec";
+
+describe("As a beacon owner, I want to submit information about my vessel", () => {
+  const pageLocation = "/register-a-beacon/about-the-vessel";
+
+  beforeEach(() => {
+    givenIAmOnTheAboutTheVesselPage();
+  });
+
+  it("displays an error if no max capacity is entered", () => {
+    whenIClickContinue();
+    thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
+  });
+
+  it("displays an error if an invalid max capacity is entered", () => {
+    whenIType("Max Capacity", "maxCapacity");
+    whenIClickContinue();
+
+    thenIShouldSeeAnErrorMessageThatContains(mustBeAnIntegerErrorMessage);
+  });
+
+  describe("when a valid maxCapacity is entered", function () {
+    beforeEach(() => {
+      whenIType("42", "maxCapacity");
+    });
+
+    it("displays an error if Area of Operation input has too many characters", () => {
+      whenIType("a".repeat(251), "areaOfOperation");
+
+      whenIClickContinue();
+      thenIShouldSeeAnErrorMessageThatContains(tooManyCharactersErrorMessage);
+    });
+
+    it("displays an error if Beacon Location input has too many characters", () => {
+      whenIType("a".repeat(101), "beaconLocation");
+
+      whenIClickContinue();
+      thenIShouldSeeAnErrorMessageThatContains(tooManyCharactersErrorMessage);
+    });
+
+    it("routes to the next page if there are no errors with form submission", () => {
+      whenIType("Earth", "areaOfOperation");
+      whenIType("With my towel", "beaconLocation");
+
+      whenIClickContinue();
+
+      thenTheUrlShouldContain("/register-a-beacon/vessel-communications");
+    });
+  });
+
+  const givenIAmOnTheAboutTheVesselPage = () => {
+    cy.visit("/");
+    cy.visit(pageLocation);
+  };
+});

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
+    "target": "es6",
+    "lib": ["es6", "dom"],
     "types": ["cypress"]
   },
   "include": ["**/*.ts"]

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -46,7 +46,7 @@ const definePageForm = ({
     beaconLocation: new FieldManager(beaconLocation, [
       Validators.maxLength(
         "Where the beacon is kept has too many characters",
-        250
+        100
       ),
     ]),
   });


### PR DESCRIPTION
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add cypress tests for `about-the-vessel` page and fix character count validation
- Change the `tsconfig` in `cypress/` to target (not sure what the appropriate verb is 😬 ) `es6` instead of `es5`
  - This was to stop Typescript(or ESLint?) moaning about this
  - I don't think it was actually a big issue, it didn't stop the app or cause tests to fail
  - But the change doesn't seem to break anything and makes TS/ESLint happier?
<img width="648" alt="image" src="https://user-images.githubusercontent.com/32230328/110523003-77d3f380-8109-11eb-822c-9747ae4a0203.png">

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/U7YwzUsE/282-set-up-functional-integration-tests-to-frontend