### PR TITLE
Rationalise Cypress element selectors

### DIFF
--- a/cypress/integration/beaconInformation.spec.ts
+++ b/cypress/integration/beaconInformation.spec.ts
@@ -18,81 +18,84 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   });
 
   it("routes to the next page if there are no errors with the form submission", () => {
-    whenIType("ASOS", "manufacturerSerialNumber");
+    whenIType("ASOS", "#manufacturerSerialNumber");
     whenIClickContinue();
 
     thenTheUrlShouldContain("/register-a-beacon/primary-beacon-use");
   });
 
-  it("displays errors if no manufacturer serial number is submitted", () => {
-    whenIClickContinue();
-    thenIShouldSeeAnErrorSummaryLinkThatContains(requiredFieldErrorMessage);
+  describe("the manufacturer serial number field", () => {
+    it("displays errors if no manufacturer serial number is submitted", () => {
+      whenIType(" ", "#manufacturerSerialNumber");
+      whenIClickContinue();
+      thenIShouldSeeAnErrorSummaryLinkThatContains(requiredFieldErrorMessage);
+    });
   });
 
   it("adds a leading zero to the battery expiry and last serviced month", () => {
-    whenIType("1", "batteryExpiryDateMonth");
-    whenIType("1", "lastServicedDateMonth");
+    whenIType("1", "#batteryExpiryDateMonth");
+    whenIType("1", "#lastServicedDateMonth");
     whenIClickContinue();
 
-    thenTheInputShouldContain("01", "batteryExpiryDateMonth");
-    thenTheInputShouldContain("01", "lastServicedDateMonth");
+    thenTheInputShouldContain("01", "#batteryExpiryDateMonth");
+    thenTheInputShouldContain("01", "#lastServicedDateMonth");
   });
 
   it("displays errors if the battery expiry month is invalid", () => {
-    whenIType("00", "batteryExpiryDateMonth");
-    whenIType("2021", "batteryExpiryDateYear");
+    whenIType("00", "#batteryExpiryDateMonth");
+    whenIType("2021", "#batteryExpiryDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct battery expiry date");
 
-    whenIType("13", "batteryExpiryDateMonth");
-    whenIType("2021", "batteryExpiryDateYear");
+    whenIType("13", "#batteryExpiryDateMonth");
+    whenIType("2021", "#batteryExpiryDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct battery expiry date");
   });
 
   it("displays errors if the battery expiry year is invalid", () => {
-    whenIType("01", "batteryExpiryDateMonth");
-    whenIType("202n", "batteryExpiryDateYear");
+    whenIType("01", "#batteryExpiryDateMonth");
+    whenIType("202n", "#batteryExpiryDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct battery expiry date");
   });
 
   it("displays errors if the battery expiry date is a valid date but before 1980", () => {
-    whenIType("01", "batteryExpiryDateMonth");
-    whenIType("1979", "batteryExpiryDateYear");
+    whenIType("01", "#batteryExpiryDateMonth");
+    whenIType("1979", "#batteryExpiryDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains(mustBeAfter1980ErrorMessage);
   });
 
   it("displays errors if the last serviced month is invalid", () => {
-    whenIType("00", "lastServicedDateMonth");
-    whenIType("2021", "lastServicedDateYear");
+    whenIType("00", "#lastServicedDateMonth");
+    whenIType("2021", "#lastServicedDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct last serviced date");
 
-    whenIType("13", "lastServicedDateMonth");
-    whenIType("2021", "lastServicedDateYear");
+    whenIType("13", "#lastServicedDateMonth");
+    whenIType("2021", "#lastServicedDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct last serviced date");
   });
 
   it("displays errors if the last serviced year is invalid", () => {
-    whenIType("01", "lastServicedDateMonth");
-    whenIType("202n", "lastServicedDateYear");
+    whenIType("01", "#lastServicedDateMonth");
+    whenIType("202n", "#lastServicedDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains("correct last serviced date");
   });
 
   it("displays errors if the last serviced date is a valid date but before 1980", () => {
-    whenIType("01", "lastServicedDateMonth");
-    whenIType("1979", "lastServicedDateYear");
+    whenIType("01", "#lastServicedDateMonth");
+    whenIType("1979", "#lastServicedDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains(mustBeAfter1980ErrorMessage);
@@ -101,8 +104,8 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   it("displays errors if the last serviced date in the future", () => {
     const date = new Date();
     const futureYear = date.getFullYear() + 1;
-    whenIType(`${date.getMonth()}`, "lastServicedDateMonth");
-    whenIType(`${futureYear}`, "lastServicedDateYear");
+    whenIType(`${date.getMonth()}`, "#lastServicedDateMonth");
+    whenIType(`${futureYear}`, "#lastServicedDateYear");
     whenIClickContinue();
 
     thenIShouldSeeAnErrorSummaryLinkThatContains(dateInThePastErrorMessage);

--- a/cypress/integration/checkBeaconDetailsPage.spec.ts
+++ b/cypress/integration/checkBeaconDetailsPage.spec.ts
@@ -5,7 +5,7 @@ import {
   thenMyFocusMovesTo,
   thenTheUrlShouldContain,
   whenIClickContinue,
-  whenIClickOnTheErrorSummaryLinkContainingText,
+  whenIClickOnTheErrorSummaryLinkContaining,
   whenIType,
 } from "./common.spec";
 
@@ -22,100 +22,100 @@ describe("As a beacon owner, I want to enter my initial beacon information", () 
   });
 
   it("errors if I submit just whitespace in the manufacturer field", () => {
-    whenIType(" ", "manufacturer");
+    whenIType(" ", "#manufacturer");
 
     whenIClickContinue();
     thenIShouldSeeAnErrorSummaryLinkThatContains("manufacturer", "required");
     thenIShouldSeeAnErrorMessageThatContains("manufacturer", "required");
 
-    whenIClickOnTheErrorSummaryLinkContainingText("manufacturer", "required");
-    thenMyFocusMovesTo("manufacturer");
+    whenIClickOnTheErrorSummaryLinkContaining("manufacturer", "required");
+    thenMyFocusMovesTo("#manufacturer");
   });
 
   it("errors if I submit just whitespace in the model field", () => {
-    whenIType(" ", "model");
+    whenIType(" ", "#model");
 
     whenIClickContinue();
     thenIShouldSeeAnErrorSummaryLinkThatContains("model", "required");
     thenIShouldSeeAnErrorMessageThatContains("model", "required");
 
-    whenIClickOnTheErrorSummaryLinkContainingText("model", "required");
-    thenMyFocusMovesTo("model");
+    whenIClickOnTheErrorSummaryLinkContaining("model", "required");
+    thenMyFocusMovesTo("#model");
   });
 
   describe("the HEX ID field", () => {
-    const hexIdField = "hexId";
+    const hexIdFieldSelector = "#hexId";
 
     it("errors if I submit just whitespace string", () => {
       const expectedErrorMessage = ["HEX ID", "required"];
 
-      whenIType(" ", "hexId");
+      whenIType(" ", "#hexId");
       whenIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
 
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo(hexIdField);
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(hexIdFieldSelector);
     });
 
     it("errors if I submit a non-hexadecimal string", () => {
       const expectedErrorMessage = ["HEX ID", "0 to 9", "A to F"];
 
-      whenIType("0123456789ABCDX", "hexId");
+      whenIType("0123456789ABCDX", "#hexId");
 
       whenIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
 
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo(hexIdField);
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(hexIdFieldSelector);
     });
 
     it("errors if I submit a string not exactly 15 characters long", () => {
       const expectedErrorMessage = ["15 characters"];
 
-      whenIType("0123456789ABCDEF", "hexId");
+      whenIType("0123456789ABCDEF", "#hexId");
 
       whenIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
 
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo(hexIdField);
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(hexIdFieldSelector);
     });
 
     it("errors if I submit a valid but non-UK HEX ID", () => {
       const expectedErrorMessage = ["UK-encoded"];
 
-      whenIType("C00F429578002C1", "hexId");
+      whenIType("C00F429578002C1", "#hexId");
 
       whenIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
 
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo(hexIdField);
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(hexIdFieldSelector);
     });
 
     it("reminds me to check for mixed up 'O's and '0's", () => {
       const expectedErrorMessage = ["O", "Did you mean", "zero"];
       const almostValidHexIdButWithOhInsteadOfZero = "1DOEAO8C52FFBFF";
 
-      whenIType(almostValidHexIdButWithOhInsteadOfZero, "hexId");
+      whenIType(almostValidHexIdButWithOhInsteadOfZero, "#hexId");
       whenIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
 
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo(hexIdField);
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(hexIdFieldSelector);
     });
   });
 
   it("routes to the next page if there are no errors with the form submission", () => {
-    whenIType("Test Manufacturer", "manufacturer");
-    whenIType("Test Model", "model");
-    whenIType(validUkEncodedHexId, "hexId");
+    whenIType("Test Manufacturer", "#manufacturer");
+    whenIType("Test Model", "#model");
+    whenIType(validUkEncodedHexId, "#hexId");
 
     whenIClickContinue();
 

--- a/cypress/integration/common.spec.ts
+++ b/cypress/integration/common.spec.ts
@@ -20,7 +20,7 @@ export const whenIClickContinue = (): void => {
 
 export const andIClickContinue = whenIClickContinue;
 
-export const whenIClickOnTheErrorSummaryLinkContainingText = (
+export const whenIClickOnTheErrorSummaryLinkContaining = (
   ...strings: string[]
 ): void => {
   let link = cy.get(".govuk-error-summary__list");
@@ -28,8 +28,8 @@ export const whenIClickOnTheErrorSummaryLinkContainingText = (
   link.click();
 };
 
-export const whenIType = (value: string, inputName: string): void => {
-  cy.get(`input[name="${inputName}"]`).clear().type(value);
+export const whenIType = (value: string, selector: string): void => {
+  cy.get(selector).clear().type(value);
 };
 
 export const thenTheUrlShouldContain = (urlPath: string): void => {
@@ -38,9 +38,9 @@ export const thenTheUrlShouldContain = (urlPath: string): void => {
 
 export const thenTheInputShouldContain = (
   expectedValue: string,
-  inputName: string
+  selector: string
 ): void => {
-  cy.get(`input[name="${inputName}"]`).should("contain.value", expectedValue);
+  cy.get(selector).should("contain.value", expectedValue);
 };
 
 export const thenIShouldSeeAnErrorSummaryLinkThatContains = (
@@ -59,18 +59,10 @@ export const thenIShouldSeeAnErrorMessageThatContains = (
   );
 };
 
-export const thenMyFocusMovesTo = (elementId: string): void => {
-  cy.focused().should("have.attr", "id", elementId);
+export const thenMyFocusMovesTo = (selector: string): void => {
+  cy.get(selector).should("be.focused");
 };
 
-export const givenIHaveSelected = (optionId: string): void => {
-  cy.get(optionId).check();
-};
-
-export const finallyIClear = (textInputSelector: string): void => {
-  cy.get(textInputSelector).clear();
-};
-
-export const finallyIUncheck = (checkboxSelector: string): void => {
-  cy.get(checkboxSelector).uncheck();
+export const givenIHaveSelected = (selector: string): void => {
+  cy.get(selector).check();
 };

--- a/cypress/integration/primaryBeaconUse.spec.ts
+++ b/cypress/integration/primaryBeaconUse.spec.ts
@@ -34,7 +34,7 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
 
   it("routes to the next page if there are no errors with Other pleasure vessel selected", () => {
     givenIHaveSelected("#other-pleasure-vessel");
-    whenIType("Surfboard", "otherPleasureVesselText");
+    whenIType("Surfboard", "#otherPleasureVesselText");
     whenIClickContinue();
 
     thenTheUrlShouldContain("/register-a-beacon/about-the-vessel");

--- a/cypress/integration/vesselCommunications.spec.ts
+++ b/cypress/integration/vesselCommunications.spec.ts
@@ -8,12 +8,20 @@ import {
   thenMyFocusMovesTo,
   thenTheUrlShouldContain,
   whenIClickContinue,
-  whenIClickOnTheErrorSummaryLinkContainingText,
+  whenIClickOnTheErrorSummaryLinkContaining,
   whenIType,
 } from "./common.spec";
 
 describe("As a beacon owner and maritime pleasure vessel user", () => {
   const pageUrl = "/register-a-beacon/vessel-communications";
+  const fixedVhfDscRadioCheckboxSelector = "#fixedVhfRadio";
+  const fixedVhfDscRadioInputSelector = "#fixedVhfRadioInput";
+  const portableVhfDscRadioCheckboxSelector = "#portableVhfRadio";
+  const portableVhfDscRadioInputSelector = "#portableVhfRadioInput";
+  const satelliteTelephoneCheckboxSelector = "#satelliteTelephone";
+  const satelliteTelephoneInputSelector = "#satelliteTelephoneInput";
+  const mobileTelephoneCheckboxSelector = "#mobileTelephone";
+  const mobileTelephoneInputSelector = "#mobileTelephoneInput1";
 
   beforeEach(() => {
     givenIAmAt(pageUrl);
@@ -22,55 +30,55 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
   describe("the Fixed VHF/DSC radio option", () => {
     it("requires an MMSI number if the fixed VHF/DSC radio checkbox is selected", () => {
       const expectedErrorMessage = ["We need", "fixed VHF"];
-      givenIHaveSelected("#fixedVhfRadio");
+      givenIHaveSelected(fixedVhfDscRadioCheckboxSelector);
 
-      whenIType(" ", "fixedVhfRadioInput");
+      whenIType(" ", fixedVhfDscRadioInputSelector);
       whenIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("fixedVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(fixedVhfDscRadioInputSelector);
     });
 
     it("requires the fixed MMSI number to be 9 characters long", () => {
       const expectedErrorMessage = ["MMSI number", "nine digits long"];
-      givenIHaveSelected("#fixedVhfRadio");
+      givenIHaveSelected(fixedVhfDscRadioCheckboxSelector);
 
-      whenIType("012345678910", "fixedVhfRadioInput");
+      whenIType("012345678910", fixedVhfDscRadioInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("fixedVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(fixedVhfDscRadioInputSelector);
     });
 
     it("requires the fixed MMSI number to be numbers 0 to 9 only", () => {
       const expectedErrorMessage = ["MMSI number", "numbers", "0 to 9"];
-      givenIHaveSelected("#fixedVhfRadio");
+      givenIHaveSelected(fixedVhfDscRadioCheckboxSelector);
 
-      whenIType("9charslng", "fixedVhfRadioInput");
+      whenIType("9charslng", fixedVhfDscRadioInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("fixedVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(fixedVhfDscRadioInputSelector);
     });
   });
 
   describe("the Portable VHF/DSC radio option", () => {
     it("requires an MMSI number if the portable VHF checkbox is selected", () => {
       const expectedErrorMessage = ["We need", "portable VHF"];
-      givenIHaveSelected("#portableVhfRadio");
+      givenIHaveSelected(portableVhfDscRadioCheckboxSelector);
 
-      whenIType(" ", "portableVhfRadioInput");
+      whenIType(" ", portableVhfDscRadioInputSelector);
       whenIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("portableVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(portableVhfDscRadioInputSelector);
     });
 
     it("requires the portable MMSI number to be 9 characters long", () => {
@@ -79,15 +87,15 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
         "MMSI number",
         "nine digits long",
       ];
-      givenIHaveSelected("#portableVhfRadio");
+      givenIHaveSelected(portableVhfDscRadioCheckboxSelector);
 
-      whenIType("012345678910", "portableVhfRadioInput");
+      whenIType("012345678910", portableVhfDscRadioInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("portableVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(portableVhfDscRadioInputSelector);
     });
 
     it("requires the portable MMSI number to be numbers 0 to 9 only", () => {
@@ -97,14 +105,14 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
         "numbers",
         "0 to 9",
       ];
-      givenIHaveSelected("#portableVhfRadio");
+      givenIHaveSelected(portableVhfDscRadioCheckboxSelector);
 
-      whenIType("9charslng", "portableVhfRadioInput");
+      whenIType("9charslng", portableVhfDscRadioInputSelector);
       andIClickContinue();
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("portableVhfRadioInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(portableVhfDscRadioInputSelector);
     });
   });
 
@@ -112,15 +120,15 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
     it("requires a phone number if the satellite telephone checkbox is selected", () => {
       const expectedErrorMessage = ["We need", "satellite telephone"];
 
-      givenIHaveSelected("#satelliteTelephone");
+      givenIHaveSelected(satelliteTelephoneCheckboxSelector);
 
-      whenIType(" ", "satelliteTelephoneInput");
+      whenIType(" ", satelliteTelephoneInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("satelliteTelephoneInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(satelliteTelephoneInputSelector);
     });
 
     it("requires the satellite phone number to be valid", () => {
@@ -130,15 +138,15 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
         "correct format",
       ];
 
-      givenIHaveSelected("#satelliteTelephone");
+      givenIHaveSelected(satelliteTelephoneCheckboxSelector);
 
-      whenIType(invalidSatelliteNumber, "satelliteTelephoneInput");
+      whenIType(invalidSatelliteNumber, satelliteTelephoneInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("satelliteTelephoneInput");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(satelliteTelephoneInputSelector);
     });
   });
 
@@ -146,30 +154,30 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
     it("requires a phone number if the mobile telephone checkbox is selected", () => {
       const expectedErrorMessage = ["We need", "mobile telephone"];
 
-      givenIHaveSelected("#mobileTelephone");
+      givenIHaveSelected(mobileTelephoneCheckboxSelector);
 
-      whenIType(" ", "mobileTelephoneInput1");
+      whenIType(" ", mobileTelephoneInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("mobileTelephoneInput1");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(mobileTelephoneInputSelector);
     });
 
     it("requires the mobile phone number to be valid", () => {
       const tooLongMobileNumber = "+44 71234567891";
       const expectedErrorMessage = ["mobile telephone", "like"];
 
-      givenIHaveSelected("#mobileTelephone");
+      givenIHaveSelected(mobileTelephoneCheckboxSelector);
 
-      whenIType(tooLongMobileNumber, "mobileTelephoneInput1");
+      whenIType(tooLongMobileNumber, mobileTelephoneInputSelector);
       andIClickContinue();
 
       thenIShouldSeeAnErrorSummaryLinkThatContains(...expectedErrorMessage);
       thenIShouldSeeAnErrorMessageThatContains(...expectedErrorMessage);
-      whenIClickOnTheErrorSummaryLinkContainingText(...expectedErrorMessage);
-      thenMyFocusMovesTo("mobileTelephoneInput1");
+      whenIClickOnTheErrorSummaryLinkContaining(...expectedErrorMessage);
+      thenMyFocusMovesTo(mobileTelephoneInputSelector);
     });
   });
 
@@ -177,15 +185,15 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
     const validMMSI = "123456789";
     const validPhoneNumber = "07887662534";
 
-    givenIHaveSelected("#fixedVhfRadio");
-    givenIHaveSelected("#portableVhfRadio");
-    givenIHaveSelected("#satelliteTelephone");
-    givenIHaveSelected("#mobileTelephone");
+    givenIHaveSelected(fixedVhfDscRadioCheckboxSelector);
+    givenIHaveSelected(portableVhfDscRadioCheckboxSelector);
+    givenIHaveSelected(satelliteTelephoneCheckboxSelector);
+    givenIHaveSelected(mobileTelephoneCheckboxSelector);
 
-    whenIType(validMMSI, "fixedVhfRadioInput");
-    whenIType(validMMSI, "portableVhfRadioInput");
-    whenIType(validPhoneNumber, "satelliteTelephoneInput");
-    whenIType(validPhoneNumber, "mobileTelephoneInput1");
+    whenIType(validMMSI, fixedVhfDscRadioInputSelector);
+    whenIType(validMMSI, portableVhfDscRadioInputSelector);
+    whenIType(validPhoneNumber, satelliteTelephoneInputSelector);
+    whenIType(validPhoneNumber, mobileTelephoneInputSelector);
     andIClickContinue();
 
     thenTheUrlShouldContain("/register-a-beacon/more-vessel-details");


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

At the moment our integration test suite uses a few different methods to select elements.  For example:

```typescript
export const whenIType = (value: string, inputName: string): void => {
  cy.get(`input[name="${inputName}"]`).clear().type(value); // Select only input elements with name of inputName
};

export const thenMyFocusMovesTo = (elementId: string): void => {
  cy.focused().should("have.attr", "id", elementId); // Select by id
};

export const givenIHaveSelected = (optionId: string): void => {
  cy.get(optionId).check(); // Select by id, called optionId
};
```

I found juggling different ways of selecting elements to act/assert on confusin.  It also reduces the ability to DRY out.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

This PR moves the responsibility for deciding what/how to select an element out of `common.spec.ts` and to the test itself.  All common functions that select DOM elements now use the generic `selector` parameter. "selector" is chosen because `cy.get()` takes a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) as its argument.

For example:

```typescript
export const whenIType = (value: string, selector: string): void => {
  cy.get(selector).clear().type(value);
};

export const thenMyFocusMovesTo = (selector: string): void => {
  cy.get(selector).should("be.focused");
};

export const givenIHaveSelected = (selector: string): void => {
  cy.get(selector).check();
};
```

This allows for neater page tests with reduced duplication:

```typescript
  it("submits the form if all fields are valid", () => {
    const validMMSI = "123456789";
    const validPhoneNumber = "07887662534";

    givenIHaveSelected(fixedVhfDscRadioCheckboxSelector);
    givenIHaveSelected(portableVhfDscRadioCheckboxSelector);
    givenIHaveSelected(satelliteTelephoneCheckboxSelector);
    givenIHaveSelected(mobileTelephoneCheckboxSelector);

    whenIType(validMMSI, fixedVhfDscRadioInputSelector);
    whenIType(validMMSI, portableVhfDscRadioInputSelector);
    whenIType(validPhoneNumber, satelliteTelephoneInputSelector);
    whenIType(validPhoneNumber, mobileTelephoneInputSelector);
    andIClickContinue();

    thenTheUrlShouldContain("/register-a-beacon/more-vessel-details");
  });
```
