### PR TITLE
Pass input to integration repo when triggering pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,4 +151,4 @@ jobs:
         run: |
           curl -X POST  -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.MCA_GITHUB_TOKEN }}" \
             https://api.github.com/repos/mcagov/beacons-integration/actions/workflows/main.yml/dispatches \
-            -d '{"ref":"main", "event_type":"update_webapp_image_tag", "client_payload": { "update_image_tags": "true"}}}'
+            -d '{"ref":"main", "inputs": { "update_image_tags": "true"}}}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,4 +151,4 @@ jobs:
         run: |
           curl -X POST  -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.MCA_GITHUB_TOKEN }}" \
             https://api.github.com/repos/mcagov/beacons-integration/actions/workflows/main.yml/dispatches \
-            -d '{"ref":"main", "inputs": { "update_image_tags": "true"}}}'
+            -d '{"ref":"main", "inputs": {"updateImageTags": "true"}}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,4 +150,5 @@ jobs:
       - name: Trigger Integration Pipeline
         run: |
           curl -X POST  -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ secrets.MCA_GITHUB_TOKEN }}" \
-            https://api.github.com/repos/mcagov/beacons-integration/actions/workflows/main.yml/dispatches -d '{"ref":"main"}'
+            https://api.github.com/repos/mcagov/beacons-integration/actions/workflows/main.yml/dispatches \
+            -d '{"ref":"main", "event_type":"update_webapp_image_tag", "client_payload": { "update_image_tags": "true"}}}'


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We use a ~repository~ workflow dispatch event to trigger the integration pipeline

We want to have a conditional job in the integration repo that only runs when it's triggered by the webapp and service.

Change in this PR: https://github.com/mcagov/beacons-integration/pull/25

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Pass `updateImageTags = true` input with the workflow dispatch event.

~Add `client_payload` parameter to curl command with input `update_image_tags`~
- ~This will be used in the integration project to conditionally run a job that we only want to run when triggered by the webapp/service~
 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
~https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event~
~https://goobar.io/manually-trigger-a-github-actions-workflow/~

