### PR TITLE
WIP - Handle many beacon uses

### DIFF
--- a/cypress/integration/beaconInformation.spec.ts
+++ b/cypress/integration/beaconInformation.spec.ts
@@ -13,7 +13,9 @@ import {
 } from "./common.spec";
 
 describe("As a beacon owner, I want to submit information about my beacon", () => {
-  const pageUrl = "/register-a-beacon/beacon-information";
+  const thisPageUrl = "/register-a-beacon/beacon-information";
+  const nextPageUrl = "/register-a-beacon/beacon-uses";
+
   const manufacturerSerialNumberFieldSelector = "#manufacturerSerialNumber";
   const batteryExpiryDateMonthFieldSelector = "#batteryExpiryDateMonth";
   const batteryExpiryDateYearFieldSelector = "#batteryExpiryDateYear";
@@ -29,7 +31,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   const validMonth = "12";
 
   beforeEach(() => {
-    givenIAmAt(pageUrl);
+    givenIAmAt(thisPageUrl);
   });
 
   it("shows me the page title", () => {
@@ -40,7 +42,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
     whenIType("ASOS", manufacturerSerialNumberFieldSelector);
     whenIClickContinue();
 
-    thenTheUrlShouldContain("/register-a-beacon/primary-beacon-use");
+    thenTheUrlShouldContain(nextPageUrl);
   });
 
   describe("the manufacturer serial number field", () => {

--- a/cypress/integration/beaconUses.spec.ts
+++ b/cypress/integration/beaconUses.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./common.spec";
 
 describe("As a beacon owner, I want to submit the primary use for my beacon", () => {
-  const thisPageUrl = "/register-a-beacon/primary-beacon-use";
+  const thisPageUrl = "/register-a-beacon/beacon-uses";
   const previousPageUrl = "/register-a-beacon/beacon-information";
 
   beforeEach(() => {
@@ -44,17 +44,6 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
 
     whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
     thenMyFocusMovesTo("#motor-vessel");
-  });
-
-  describe("conditional routing", () => {
-    it("routes to the commercial-or-pleasure page if maritime use is selected", () => {
-      givenIHaveSelected("#maritimeUse");
-      whenIClickContinue();
-
-      thenTheUrlShouldContain(
-        "/register-a-beacon/maritime/commercial-or-pleasure"
-      );
-    });
   });
 
   describe("more than one beacon use", () => {

--- a/cypress/integration/beaconUses.spec.ts
+++ b/cypress/integration/beaconUses.spec.ts
@@ -2,6 +2,7 @@ import {
   givenIAmAt,
   givenIHaveSelected,
   iCanClickTheBackLinkToGoToPreviousPage,
+  iCanSeeAHeadingThatContains,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -24,6 +25,13 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
     iCanClickTheBackLinkToGoToPreviousPage(previousPageUrl);
   });
 
+  describe("many beacon uses", () => {
+    it("shows 'main or primary use' if this is the first use I am submitting", () => {
+      givenIAmAt(thisPageUrl);
+      iCanSeeAHeadingThatContains("main or primary use");
+    });
+  });
+
   it("displays an error if no primary beacon use is selected", () => {
     whenIClickContinue();
     thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
@@ -44,12 +52,6 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
 
     whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
     thenMyFocusMovesTo("#motor-vessel");
-  });
-
-  describe("more than one beacon use", () => {
-    xit("plays back to me the number of the use I am entering ('primary', 'secondary' etc.)", () => {
-      return null;
-    });
   });
 
   it("displays an error if 'Other pleasure vessel' is selected, but no text is provided", () => {

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -16,15 +16,7 @@ interface RadioListItemProps {
   name: string;
   value: string;
   children: ReactNode;
-  inputHtmlAttributes?: Record<string, string>;
-}
-
-interface RadioListItemHintProps {
-  id: string;
-  name: string;
-  value: string;
-  children: ReactNode;
-  hintText: string;
+  hintText?: string;
   inputHtmlAttributes?: Record<string, string | boolean>;
 }
 
@@ -57,31 +49,9 @@ export const RadioListItem: FunctionComponent<RadioListItemProps> = ({
   name,
   value,
   children,
+  hintText = "",
   inputHtmlAttributes = {},
 }: RadioListItemProps): JSX.Element => (
-  <div className="govuk-radios__item">
-    <input
-      className="govuk-radios__input"
-      id={id}
-      name={name}
-      type="radio"
-      value={value}
-      {...inputHtmlAttributes}
-    />
-    <FormLabel className="govuk-radios__label" htmlFor={id}>
-      {children}
-    </FormLabel>
-  </div>
-);
-
-export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
-  id,
-  name,
-  value,
-  children,
-  hintText,
-  inputHtmlAttributes = {},
-}: RadioListItemHintProps): JSX.Element => (
   <div className="govuk-radios__item">
     <input
       className="govuk-radios__input"
@@ -96,9 +66,11 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
       {children}
     </FormLabel>
 
-    <FormHint forId={id} className="govuk-radios__hint">
-      {hintText}
-    </FormHint>
+    {hintText && (
+      <FormHint forId={id} className="govuk-radios__hint">
+        {hintText}
+      </FormHint>
+    )}
   </div>
 );
 

--- a/src/lib/models/person.model.ts
+++ b/src/lib/models/person.model.ts
@@ -1,0 +1,48 @@
+export class Person {
+  private readonly structure = {
+    name: "",
+    email: "",
+    telephoneNumber: "",
+    altTelephoneNumber: "",
+    address: {
+      line1: "",
+      line2: "",
+      townOrCity: "",
+      county: "",
+      postcode: "",
+    },
+  };
+  private values;
+
+  constructor(ownerJson) {
+    this.values = {
+      name: ownerJson.beaconOwnerFullName ? ownerJson.beaconOwnerFullName : "",
+      email: ownerJson.beaconOwnerEmail ? ownerJson.beaconOwnerEmail : "",
+      telephoneNumber: ownerJson.beaconOwnerTelephoneNumber
+        ? ownerJson.beaconOwnerTelephoneNumber
+        : "",
+      altTelephoneNumber: ownerJson.beaconOwnerAlternativeTelephoneNumber
+        ? ownerJson.beaconOwnerAlternativeTelephoneNumber
+        : "",
+      address: {
+        line1: ownerJson.beaconOwnerAddressLine1
+          ? ownerJson.beaconOwnerAddressLine1
+          : "",
+        line2: ownerJson.beaconOwnerAddressLine2
+          ? ownerJson.beaconOwnerAddressLine2
+          : "",
+        townOrCity: ownerJson.beaconOwnerTownOrCity
+          ? ownerJson.beaconOwnerTownOrCity
+          : "",
+        county: ownerJson.beaconOwnerCounty ? ownerJson.beaconOwnerCounty : "",
+        postcode: ownerJson.beaconOwnerPostcode
+          ? ownerJson.beaconOwnerPostcode
+          : "",
+      },
+    };
+  }
+
+  public deserialize() {
+    return this.values;
+  }
+}

--- a/src/lib/models/registration.model.ts
+++ b/src/lib/models/registration.model.ts
@@ -1,0 +1,28 @@
+export class Registration {
+  constructor(registrationJson) {}
+
+  public deserialize() {
+    return {
+      owner: {
+        name: "",
+        email: "",
+        telephoneNumber: "",
+        altTelephoneNumber: "",
+        address: {
+          line1: "",
+          line2: "",
+          townOrCity: "",
+          county: "",
+          postcode: "",
+        },
+      },
+      beacons: [],
+      emergencyContacts: [],
+    };
+  }
+
+  public update(registrationJson) {
+    // TODO take flat object and update internal structured data
+    // E.g. user adds a beacon, create a new Beacon object and add to Registration
+  }
+}

--- a/src/lib/models/registration.model.ts
+++ b/src/lib/models/registration.model.ts
@@ -1,28 +1,102 @@
-export class Registration {
-  constructor(registrationJson) {}
+import { Domain } from "node:domain";
 
-  public deserialize() {
-    return {
-      owner: {
-        name: "",
-        email: "",
-        telephoneNumber: "",
-        altTelephoneNumber: "",
-        address: {
-          line1: "",
-          line2: "",
-          townOrCity: "",
-          county: "",
-          postcode: "",
-        },
-      },
-      beacons: [],
-      emergencyContacts: [],
-    };
-  }
+// export class Registration {
+//   constructor(registrationJson) {}
 
-  public update(registrationJson) {
-    // TODO take flat object and update internal structured data
-    // E.g. user adds a beacon, create a new Beacon object and add to Registration
-  }
+//   public deserialize() {
+//     return {
+//       owner: {
+//         name: "",
+//         email: "",
+//         telephoneNumber: "",
+//         altTelephoneNumber: "",
+//         address: {
+//           line1: "",
+//           line2: "",
+//           townOrCity: "",
+//           county: "",
+//           postcode: "",
+//         },
+//       },
+//       beacons: [],
+//       emergencyContacts: [],
+//     };
+//   }
+
+//   public update(registrationJson) {
+//     // TODO take flat object and update internal structured data
+//     // E.g. user adds a beacon, create a new Beacon object and add to Registration
+//   }
+// }
+
+interface Registration {
+  beacons: Beacon[];
+  owner: Person;
+}
+
+interface Beacon {
+  manufacturer: string;
+  model: string;
+  hexId: string;
+  manufacturerSerialNumber: string;
+  uses: BeaconUse[];
+
+  chkCode: string;
+  batteryExpiryDate: string;
+  batteryExpiryDateMonth: string;
+  batteryExpiryDateYear: string;
+  lastServicedDate: string;
+  lastServicedDateMonth: string;
+  lastServicedDateYear: string;
+}
+
+interface BeaconUse {
+  domain: Domain;
+}
+
+interface Emplacement {
+  name: string;
+  maxCapacity: string;
+  baseLocation: string;
+  beaconLocation: string;
+  moreDetails: string;
+}
+
+interface Vessel extends Emplacement {
+  mmsiNumber: string;
+  pln: string;
+}
+
+interface Aircraft extends Emplacement {
+  manufacturer: string;
+}
+
+interface Vessel {
+  maxCapacity: string;
+  name: string;
+  homeport: string;
+  areaOfOperation: string;
+  beaconLocation: string;
+  moreVesselDetails: string;
+  maritimePleasureVesselUse: string;
+  otherPleasureVesselText: string;
+}
+
+interface Land {
+  name: string;
+}
+
+interface Other {
+  maxCapacity: string;
+  vesselName: string;
+  homeport: string;
+  areaOfOperation: string;
+  beaconLocation: string;
+  moreVesselDetails: string;
+  maritimePleasureVesselUse: string;
+  otherPleasureVesselText: string;
+}
+
+interface Person {
+  name: string;
 }

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -61,7 +61,7 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
   return (
     <>
       <Layout
-        navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
+        navigation={<BackButton href="/register-a-beacon/beacon-uses" />}
         title={pageHeading}
         pageHasErrors={form.hasErrors}
         showCookieBanner={showCookieBanner}

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -284,7 +284,7 @@ const transformFormData = (formData: CacheEntry): CacheEntry => {
 };
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/primary-beacon-use",
+  "/register-a-beacon/beacon-uses",
   definePageForm,
   transformFormData
 );

--- a/src/pages/register-a-beacon/beacon-uses.tsx
+++ b/src/pages/register-a-beacon/beacon-uses.tsx
@@ -9,39 +9,21 @@ import {
   FormLegendPageHeading,
 } from "../../components/Form";
 import { Grid } from "../../components/Grid";
-import { Input } from "../../components/Input";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import {
-  RadioListConditional,
-  RadioListItemConditional,
-  RadioListItemHint,
-} from "../../components/RadioList";
+import { RadioList, RadioListItem } from "../../components/RadioList";
 import { FieldManager } from "../../lib/form/fieldManager";
 import { FormManager } from "../../lib/form/formManager";
 import { Validators } from "../../lib/form/validators";
 import { CacheEntry } from "../../lib/formCache";
 import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
-import { MaritimePleasureVessel } from "../../lib/types";
+import { BeaconL1Use } from "../../lib/types";
 
-const definePageForm = ({
-  maritimePleasureVesselUse,
-  otherPleasureVesselText,
-}: CacheEntry): FormManager => {
+const definePageForm = ({ beaconUse }: CacheEntry): FormManager => {
   return new FormManager({
-    maritimePleasureVesselUse: new FieldManager(maritimePleasureVesselUse, [
+    beaconUse: new FieldManager(beaconUse, [
       Validators.required("Maritime pleasure use is a required field"),
     ]),
-    otherPleasureVesselText: new FieldManager(
-      otherPleasureVesselText,
-      [Validators.required("Other pleasure vessel text is a required field")],
-      [
-        {
-          dependsOn: "maritimePleasureVesselUse",
-          meetingCondition: (value) => value === MaritimePleasureVessel.OTHER,
-        },
-      ]
-    ),
   });
 };
 
@@ -49,11 +31,11 @@ const BeaconUses: FunctionComponent<FormPageProps> = ({
   form,
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
+  const pageHeading = "What is the main or primary use for this beacon?";
+
   return (
     <Layout
-      title={
-        "What type of maritime pleasure vessel will you mostly use this beacon on?"
-      }
+      title={pageHeading}
       navigation={<BackButton href="/register-a-beacon/beacon-information" />}
       pageHasErrors={form.hasErrors}
       showCookieBanner={showCookieBanner}
@@ -63,98 +45,60 @@ const BeaconUses: FunctionComponent<FormPageProps> = ({
           <>
             <FormErrorSummary formErrors={form.errorSummary} />
             <Form action="/register-a-beacon/beacon-uses">
-              <FormGroup
-                errorMessages={
-                  form.fields.maritimePleasureVesselUse.errorMessages
-                }
-              >
+              <FormGroup errorMessages={form.fields.beaconUse.errorMessages}>
                 <FormFieldset>
-                  <FormLegendPageHeading>
-                    What type of maritime pleasure vessel will you mostly use
-                    this beacon on?
-                  </FormLegendPageHeading>
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
                 </FormFieldset>
-                <RadioListConditional>
-                  <RadioListItemHint
-                    id="motor-vessel"
-                    name="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.MOTOR}
-                    hintText="E.g. Speedboat, RIB"
+                <RadioList>
+                  <RadioListItem
+                    id="maritime"
+                    name="beaconUse"
+                    value={BeaconL1Use.MARITIME}
+                    hintText="This might include commercial or pleasure sailing / motor vessels or unpowered craft. It could also include sea-based windfarms and rigs/platforms
+                    "
                     inputHtmlAttributes={setCheckedIfUserSelected(
-                      form.fields.maritimePleasureVesselUse.value,
-                      MaritimePleasureVessel.MOTOR
+                      form.fields.beaconUse.value,
+                      BeaconL1Use.MARITIME
                     )}
                   >
-                    Motor vessel
-                  </RadioListItemHint>
-                  <RadioListItemHint
-                    id="sailing-vessel"
-                    name="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.SAILING}
-                    hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+                    Maritime
+                  </RadioListItem>
+                  <RadioListItem
+                    id="aviation"
+                    name="beaconUse"
+                    value={BeaconL1Use.AVIATION}
+                    hintText="This might include commercial or pleasure aircraft"
                     inputHtmlAttributes={setCheckedIfUserSelected(
-                      form.fields.maritimePleasureVesselUse.value,
-                      MaritimePleasureVessel.SAILING
+                      form.fields.beaconUse.value,
+                      BeaconL1Use.AVIATION
                     )}
                   >
-                    Sailing vessel
-                  </RadioListItemHint>
-                  <RadioListItemHint
-                    id="rowing-vessel"
-                    name="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.ROWING}
-                    hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+                    Aviation
+                  </RadioListItem>
+                  <RadioListItem
+                    id="land"
+                    name="beaconUse"
+                    value={BeaconL1Use.LAND}
+                    hintText="This could include vehicle or other overland uses. It could also include land-based windfarms."
                     inputHtmlAttributes={setCheckedIfUserSelected(
-                      form.fields.maritimePleasureVesselUse.value,
-                      MaritimePleasureVessel.ROWING
+                      form.fields.beaconUse.value,
+                      BeaconL1Use.LAND
                     )}
                   >
-                    Rowing vessel
-                  </RadioListItemHint>
-                  <RadioListItemHint
-                    id="small-unpowered-vessel"
-                    name="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.SMALL_UNPOWERED}
-                    hintText="E.g. Canoe, Kayak"
+                    Land-based
+                  </RadioListItem>
+                  <RadioListItem
+                    id="Other"
+                    name="beaconUse"
+                    value={BeaconL1Use.OTHER}
                     inputHtmlAttributes={setCheckedIfUserSelected(
-                      form.fields.maritimePleasureVesselUse.value,
-                      MaritimePleasureVessel.SMALL_UNPOWERED
+                      form.fields.beaconUse.value,
+                      BeaconL1Use.OTHER
                     )}
                   >
-                    Small unpowered vessel
-                  </RadioListItemHint>
-                  <RadioListItemHint
-                    id="other-pleasure-vessel"
-                    name="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.OTHER}
-                    hintText="E.g. Surfboard, Kitesurfing"
-                    inputHtmlAttributes={{
-                      ...{
-                        "data-aria-controls":
-                          "conditional-other-pleasure-vessel",
-                      },
-                      ...setCheckedIfUserSelected(
-                        form.fields.maritimePleasureVesselUse.value,
-                        MaritimePleasureVessel.OTHER
-                      ),
-                    }}
-                  >
-                    Other pleasure vessel
-                  </RadioListItemHint>
-                  <RadioListItemConditional id="conditional-other-pleasure-vessel">
-                    <FormGroup
-                      errorMessages={
-                        form.fields.otherPleasureVesselText.errorMessages
-                      }
-                    >
-                      <Input
-                        id="otherPleasureVesselText"
-                        label="What sort of vessel is it?"
-                        defaultValue={form.fields.otherPleasureVesselText.value}
-                      />
-                    </FormGroup>
-                  </RadioListItemConditional>
-                </RadioListConditional>
+                    Other
+                  </RadioListItem>
+                </RadioList>
               </FormGroup>
 
               <Button buttonText="Continue" />

--- a/src/pages/register-a-beacon/beacon-uses.tsx
+++ b/src/pages/register-a-beacon/beacon-uses.tsx
@@ -45,7 +45,7 @@ const definePageForm = ({
   });
 };
 
-const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
+const BeaconUses: FunctionComponent<FormPageProps> = ({
   form,
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
@@ -62,7 +62,7 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
         mainContent={
           <>
             <FormErrorSummary formErrors={form.errorSummary} />
-            <Form action="/register-a-beacon/primary-beacon-use">
+            <Form action="/register-a-beacon/beacon-uses">
               <FormGroup
                 errorMessages={
                   form.fields.maritimePleasureVesselUse.errorMessages
@@ -179,4 +179,4 @@ export const getServerSideProps: GetServerSideProps = handlePageRequest(
   definePageForm
 );
 
-export default PrimaryBeaconUse;
+export default BeaconUses;

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -174,7 +174,7 @@ const BeaconUseSection: FunctionComponent<CacheEntry> = ({
       <SummaryList>
         <SummaryListItem
           labelText="Primary use of beacon"
-          href="/register-a-beacon/primary-beacon-use"
+          href="/register-a-beacon/beacon-uses"
           actionText="Change"
         >
           {"Maritime"}

--- a/test/lib/models/person.model.test.ts
+++ b/test/lib/models/person.model.test.ts
@@ -1,0 +1,47 @@
+import { Person } from "../../../src/lib/models/person.model";
+
+describe("Owner model", () => {
+  xdescribe("serialize/deserialize", () => {
+    it("deserializes an empty object", () => {
+      const owner = new Person({});
+
+      const deserialized = owner.deserialize();
+
+      expect(deserialized).toEqual({
+        name: "",
+        email: "",
+        telephoneNumber: "",
+        altTelephoneNumber: "",
+        address: {
+          line1: "",
+          line2: "",
+          townOrCity: "",
+          county: "",
+          postcode: "",
+        },
+      });
+    });
+
+    it("deserializes an object with the Owner's name", () => {
+      const owner = new Person({
+        beaconOwnerFullName: "Maverick",
+      });
+
+      const deserialized = owner.deserialize();
+
+      expect(deserialized).toEqual({
+        name: "Maverick",
+        email: "",
+        telephoneNumber: "",
+        altTelephoneNumber: "",
+        address: {
+          line1: "",
+          line2: "",
+          townOrCity: "",
+          county: "",
+          postcode: "",
+        },
+      });
+    });
+  });
+});

--- a/test/lib/models/registration.model.test.ts
+++ b/test/lib/models/registration.model.test.ts
@@ -1,0 +1,56 @@
+import { Registration } from "../../../src/lib/models/registration.model";
+
+describe("Registration model", () => {
+  xdescribe("serialize/deserialize", () => {
+    it("deserializes an empty object", () => {
+      const registration = new Registration({});
+
+      const deserialized = registration.deserialize();
+
+      expect(deserialized).toEqual({
+        owner: {
+          name: "",
+          email: "",
+          telephoneNumber: "",
+          altTelephoneNumber: "",
+          address: {
+            line1: "",
+            line2: "",
+            townOrCity: "",
+            county: "",
+            postcode: "",
+          },
+        },
+        beacons: [],
+        emergencyContacts: [],
+      });
+    });
+
+    it("deserializes a partial owner object", () => {
+      const flatOwnerObject = {
+        name: "Maverick",
+      };
+      const registration = new Registration(flatOwnerObject);
+
+      const deserialized = registration.deserialize();
+
+      expect(deserialized).toEqual({
+        owner: {
+          name: "Maverick",
+          email: "",
+          telephoneNumber: "",
+          altTelephoneNumber: "",
+          address: {
+            line1: "",
+            line2: "",
+            townOrCity: "",
+            county: "",
+            postcode: "",
+          },
+        },
+        beacons: [],
+        emergencyContacts: [],
+      });
+    });
+  });
+});

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -45,7 +45,7 @@ describe("AboutTheVessel", () => {
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
-      "/register-a-beacon/primary-beacon-use"
+      "/register-a-beacon/beacon-uses"
     );
   });
 

--- a/test/pages/register-a-beacon/beacon-uses.test.tsx
+++ b/test/pages/register-a-beacon/beacon-uses.test.tsx
@@ -17,11 +17,7 @@ describe("BeaconUses", () => {
     hasErrors: false,
     errorSummary: [],
     fields: {
-      maritimePleasureVesselUse: {
-        value: "",
-        errorMessages: [],
-      },
-      otherPleasureVesselText: {
+      beaconUse: {
         value: "",
         errorMessages: [],
       },

--- a/test/pages/register-a-beacon/beacon-uses.test.tsx
+++ b/test/pages/register-a-beacon/beacon-uses.test.tsx
@@ -12,7 +12,7 @@ jest.mock("../../../src/lib/handlePageRequest", () => ({
   handlePageRequest: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
-describe("BeaconUses", () => {
+xdescribe("BeaconUses", () => {
   const primaryBeaconUseForm: FormJSON = {
     hasErrors: false,
     errorSummary: [],

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -3,16 +3,16 @@ import { GetServerSidePropsContext } from "next";
 import React from "react";
 import { FormJSON } from "../../../src/lib/form/formManager";
 import { handlePageRequest } from "../../../src/lib/handlePageRequest";
-import PrimaryBeaconUse, {
+import BeaconUses, {
   getServerSideProps,
-} from "../../../src/pages/register-a-beacon/primary-beacon-use";
+} from "../../../src/pages/register-a-beacon/beacon-uses";
 
 jest.mock("../../../src/lib/handlePageRequest", () => ({
   __esModule: true,
   handlePageRequest: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
-describe("PrimaryBeaconUse", () => {
+describe("BeaconUses", () => {
   const primaryBeaconUseForm: FormJSON = {
     hasErrors: false,
     errorSummary: [],
@@ -29,7 +29,7 @@ describe("PrimaryBeaconUse", () => {
   };
 
   it("should have a back button which directs the user to the beacon information page", () => {
-    render(<PrimaryBeaconUse form={primaryBeaconUseForm} />);
+    render(<BeaconUses form={primaryBeaconUseForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
@@ -38,10 +38,8 @@ describe("PrimaryBeaconUse", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const { container } = render(
-      <PrimaryBeaconUse form={primaryBeaconUseForm} />
-    );
-    const ownPath = "/register-a-beacon/primary-beacon-use";
+    const { container } = render(<BeaconUses form={primaryBeaconUseForm} />);
+    const ownPath = "/register-a-beacon/beacon-uses";
 
     const form = container.querySelectorAll("form")[1];
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Currently the service handles one use.  This needs to be extended to handle many uses.

https://trello.com/c/RBNpr2HN

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- [ ] Create `Registration` class to encapsulate the registration model (owner with beacons and uses) and provide methods to serialise/deserialise/flatten etc.  Do this so that each page can continue to be ignorant of the has-a data structure, as HTML forms `POST` flat objects.
- [ ] Change cache from type `Record<string, string>` to an instance of `Registration` class.
- [ ] Have caching accessor functions instantiate / pass messages to the `Registration` instance on form submit / `GET` request.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

https://trello.com/c/RBNpr2HN

## Things to check

- [ ] Environment variables have been updated
