### PR TITLE
Add about the aircraft page

### DIFF
--- a/cypress/integration/aboutTheAircraft.spec.ts
+++ b/cypress/integration/aboutTheAircraft.spec.ts
@@ -1,6 +1,7 @@
 import {
   givenIAmAt,
   givenIHaveTyped,
+  iCanClickTheBackLinkToGoToPreviousPage,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenMyFocusMovesTo,
@@ -12,6 +13,7 @@ import {
 } from "./common.spec";
 
 describe("As a beacon owner, I want to submit information about my aircraft", () => {
+  const previousPageUrl = "/register-a-beacon/primary-beacon-use";
   const thisPageUrl = "/register-a-beacon/about-the-aircraft";
   const nextPageUrl = "/register-a-beacon/aircraft-communications";
 
@@ -22,11 +24,15 @@ describe("As a beacon owner, I want to submit information about my aircraft", ()
     givenIAmAt(thisPageUrl);
   });
 
-  it("routes to the next page if there are no errors with the form submission", () => {
+  it("should route to the next page if there are no errors with the form submission", () => {
     whenIType("42", aircraftMaxCapacitySelector);
     whenIClickContinue();
 
     thenTheUrlShouldContain(nextPageUrl);
+  });
+
+  it("should route to the previous page", () => {
+    iCanClickTheBackLinkToGoToPreviousPage(previousPageUrl);
   });
 
   describe("maximum capacity field", () => {

--- a/cypress/integration/aboutTheAircraft.spec.ts
+++ b/cypress/integration/aboutTheAircraft.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIAmAt,
+  givenIHaveTyped,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenMyFocusMovesTo,
@@ -56,7 +57,7 @@ describe("As a beacon owner, I want to submit information about my aircraft", ()
     });
   });
 
-  describe("beacon position", () => {
+  describe("the beacon position", () => {
     const tooManyCharactersErrorMessageContains = [
       "Where the beacon",
       tooManyCharactersErrorMessage,
@@ -74,6 +75,15 @@ describe("As a beacon owner, I want to submit information about my aircraft", ()
         ...tooManyCharactersErrorMessageContains
       );
       thenMyFocusMovesTo(beaconPositionSelector);
+    });
+
+    it("submits if less than 100 characters are submitted", () => {
+      const requiredFieldValue = "42";
+      givenIHaveTyped(requiredFieldValue, aircraftMaxCapacitySelector);
+
+      whenIType("a".repeat(99), beaconPositionSelector);
+      whenIClickContinue();
+      thenTheUrlShouldContain(nextPageUrl);
     });
   });
 });

--- a/cypress/integration/aboutTheAircraft.spec.ts
+++ b/cypress/integration/aboutTheAircraft.spec.ts
@@ -1,0 +1,10 @@
+import { givenIAmAt } from "./common.spec";
+
+describe("As a beacon owner, I want to submit information about my aircraft", () => {
+  const thisPageUrl = "/register-a-beacon/about-the-aircraft";
+  const nextPageUrl = "/register-a-beacon/vessel-communications";
+
+  beforeEach(() => {
+    givenIAmAt(thisPageUrl);
+  });
+});

--- a/cypress/integration/aboutTheAircraft.spec.ts
+++ b/cypress/integration/aboutTheAircraft.spec.ts
@@ -1,10 +1,79 @@
-import { givenIAmAt } from "./common.spec";
+import {
+  givenIAmAt,
+  requiredFieldErrorMessage,
+  thenIShouldSeeAnErrorMessageThatContains,
+  thenMyFocusMovesTo,
+  thenTheUrlShouldContain,
+  tooManyCharactersErrorMessage,
+  whenIClickContinue,
+  whenIClickOnTheErrorSummaryLinkContaining,
+  whenIType,
+} from "./common.spec";
 
 describe("As a beacon owner, I want to submit information about my aircraft", () => {
   const thisPageUrl = "/register-a-beacon/about-the-aircraft";
-  const nextPageUrl = "/register-a-beacon/vessel-communications";
+  const nextPageUrl = "/register-a-beacon/aircraft-communications";
+
+  const aircraftMaxCapacitySelector = "#aircraftMaxCapacity";
+  const beaconPositionSelector = "#beaconPosition";
 
   beforeEach(() => {
     givenIAmAt(thisPageUrl);
+  });
+
+  it("routes to the next page if there are no errors with the form submission", () => {
+    whenIType("42", aircraftMaxCapacitySelector);
+    whenIClickContinue();
+
+    thenTheUrlShouldContain(nextPageUrl);
+  });
+
+  describe("maximum capacity field", () => {
+    it("displays errors if no maximum aircraft capacity is submitted", () => {
+      whenIClickContinue();
+      thenIShouldSeeAnErrorMessageThatContains(
+        "Maximum number of persons",
+        requiredFieldErrorMessage
+      );
+
+      whenIClickOnTheErrorSummaryLinkContaining("Maximum number of persons");
+      thenMyFocusMovesTo(aircraftMaxCapacitySelector);
+    });
+
+    it("displays errors if no the value is not a whole number", () => {
+      whenIType("1.3", aircraftMaxCapacitySelector);
+      whenIClickContinue();
+      thenIShouldSeeAnErrorMessageThatContains(
+        "Maximum number of persons",
+        "whole number"
+      );
+
+      whenIClickOnTheErrorSummaryLinkContaining(
+        "Maximum number of persons",
+        "whole number"
+      );
+      thenMyFocusMovesTo(aircraftMaxCapacitySelector);
+    });
+  });
+
+  describe("beacon position", () => {
+    const tooManyCharactersErrorMessageContains = [
+      "Where the beacon",
+      tooManyCharactersErrorMessage,
+    ];
+
+    it("displays errors if more than 100 characters", () => {
+      whenIType("a".repeat(101), beaconPositionSelector);
+      whenIClickContinue();
+
+      thenIShouldSeeAnErrorMessageThatContains(
+        ...tooManyCharactersErrorMessageContains
+      );
+
+      whenIClickOnTheErrorSummaryLinkContaining(
+        ...tooManyCharactersErrorMessageContains
+      );
+      thenMyFocusMovesTo(beaconPositionSelector);
+    });
   });
 });

--- a/cypress/integration/aboutTheVessel.spec.ts
+++ b/cypress/integration/aboutTheVessel.spec.ts
@@ -40,10 +40,6 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
         requiredFieldErrorMessage
       );
 
-      thenIShouldSeeAnErrorSummaryLinkThatContains(
-        "Maximum number of persons",
-        requiredFieldErrorMessage
-      );
       thenIShouldSeeAnErrorMessageThatContains(
         "Maximum number of persons",
         requiredFieldErrorMessage
@@ -67,9 +63,6 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
         ...mustBeAWholeNumberErrorMessageContains
       );
 
-      thenIShouldSeeAnErrorSummaryLinkThatContains(
-        ...mustBeAWholeNumberErrorMessageContains
-      );
       thenIShouldSeeAnErrorMessageThatContains(
         ...mustBeAWholeNumberErrorMessageContains
       );
@@ -93,9 +86,6 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
         ...tooLongErrorMessageContains
       );
 
-      thenIShouldSeeAnErrorSummaryLinkThatContains(
-        ...tooLongErrorMessageContains
-      );
       thenIShouldSeeAnErrorMessageThatContains(...tooLongErrorMessageContains);
 
       whenIClickOnTheErrorSummaryLinkContaining(...tooLongErrorMessageContains);
@@ -124,9 +114,6 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
         ...tooLongErrorMessageContains
       );
 
-      thenIShouldSeeAnErrorSummaryLinkThatContains(
-        ...tooLongErrorMessageContains
-      );
       thenIShouldSeeAnErrorMessageThatContains(...tooLongErrorMessageContains);
 
       whenIClickOnTheErrorSummaryLinkContaining(...tooLongErrorMessageContains);

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -87,7 +87,7 @@ export const FormLegend: FunctionComponent<FormLegendProps> = ({
 }: FormLegendProps): JSX.Element => {
   let sizeClassName = "";
 
-  if (size !== null) {
+  if (size) {
     sizeClassName =
       size === "medium"
         ? "govuk-fieldset__legend--m"

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -33,6 +33,7 @@ interface FormHintProps {
 
 interface FormLegendProps {
   className?: string;
+  size?: "small" | "medium";
   children: ReactNode;
 }
 
@@ -81,11 +82,24 @@ export const FormFieldset: FunctionComponent<FormFieldsetProps> = ({
 );
 
 export const FormLegend: FunctionComponent<FormLegendProps> = ({
-  className = "",
   children,
-}: FormLegendProps): JSX.Element => (
-  <legend className={`govuk-fieldset__legend ${className}`}>{children}</legend>
-);
+  size = null,
+}: FormLegendProps): JSX.Element => {
+  let sizeClassName = "";
+
+  if (size !== null) {
+    sizeClassName =
+      size === "medium"
+        ? "govuk-fieldset__legend--m"
+        : "govuk-fieldset__legend--s";
+  }
+
+  return (
+    <legend className={`govuk-fieldset__legend ${sizeClassName}`}>
+      {children}
+    </legend>
+  );
+};
 
 export const FormLegendPageHeading: FunctionComponent<FormLegendPageHeadingProps> = ({
   children,

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -4,6 +4,7 @@ import { FormHint, FormLabel } from "./Form";
 interface RadioListProps {
   children: ReactNode;
   conditional?: boolean;
+  small?: boolean;
 }
 
 interface RadioListItemProps {
@@ -21,12 +22,17 @@ interface RadioListItemProps {
 export const RadioList: FunctionComponent<RadioListProps> = ({
   children,
   conditional = false,
+  small = false,
 }: RadioListProps): JSX.Element => {
   const attributes = conditional ? { "data-module": "govuk-radios" } : {};
   const conditionalClassName = conditional ? "govuk-radios--conditional" : "";
+  const smallClassName = small ? "govuk-radios--small" : "";
 
   return (
-    <div className={`govuk-radios ${conditionalClassName}`} {...attributes}>
+    <div
+      className={`govuk-radios ${conditionalClassName} ${smallClassName}`}
+      {...attributes}
+    >
       {children}
     </div>
   );

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -16,6 +16,7 @@ interface TextareaProps {
 interface TextareaCharacterCountProps {
   id: string;
   maxCharacters: number;
+  errorMessages?: string[];
   label?: string;
   defaultValue?: string;
   hintText?: string;
@@ -49,6 +50,7 @@ export const Textarea: FunctionComponent<TextareaProps> = ({
 export const TextareaCharacterCount: FunctionComponent<TextareaCharacterCountProps> = ({
   id,
   maxCharacters,
+  errorMessages = [],
   label = null,
   defaultValue = "",
   hintText = null,
@@ -74,19 +76,19 @@ export const TextareaCharacterCount: FunctionComponent<TextareaCharacterCountPro
       data-module="govuk-character-count"
       data-maxlength={maxCharacters}
     >
-      <FormGroup>
+      <FormGroup errorMessages={errorMessages}>
         {labelComponent}
         {hintComponent}
+        <textarea
+          className="govuk-textarea govuk-js-character-count"
+          id={id}
+          name={name}
+          rows={rows}
+          aria-describedby={`${id}-hint ${id}-info`}
+          {...htmlAttributes}
+          defaultValue={defaultValue}
+        />
       </FormGroup>
-      <textarea
-        className="govuk-textarea govuk-js-character-count"
-        id={id}
-        name={name}
-        rows={rows}
-        aria-describedby={`${id}-hint ${id}-info`}
-        {...htmlAttributes}
-        defaultValue={defaultValue}
-      />
       <div
         id={`${id}-info`}
         className="govuk-hint govuk-character-count__message"

--- a/src/lib/formCache.ts
+++ b/src/lib/formCache.ts
@@ -1,4 +1,5 @@
 import {
+  Aircraft,
   Beacon,
   BeaconInformation,
   BeaconIntent,
@@ -13,6 +14,7 @@ type BeaconModel = Beacon &
   Owner &
   Vessel &
   VesselCommunications &
+  Aircraft &
   EmergencyContacts;
 
 // Convenience type

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -30,9 +30,6 @@ export const handlePageRequest = (
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
     const userDidSubmitForm = context.req.method === "POST";
-    // extract out beacon_index = 0
-    // extract flat beacon information
-    // pass that into the getFormPage function
 
     if (userDidSubmitForm) {
       return handlePostRequest(

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -30,6 +30,9 @@ export const handlePageRequest = (
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
     const userDidSubmitForm = context.req.method === "POST";
+    // extract out beacon_index = 0
+    // extract flat beacon information
+    // pass that into the getFormPage function
 
     if (userDidSubmitForm) {
       return handlePostRequest(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,7 +57,7 @@ export interface Vessel {
 }
 
 export interface Aircraft {
-  maxCapacity: string;
+  aircraftMaxCapacity: string;
   aircraftManufacturer: string;
   principalAirport: string;
   secondaryAirport: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,18 @@ export interface Vessel {
   otherPleasureVesselText: string;
 }
 
+export interface Aircraft {
+  maxCapacity: string;
+  aircraftManufacturer: string;
+  principalAirport: string;
+  secondaryAirport: string;
+  registrationMark: string;
+  hexAddress: string;
+  cnOrMsnNumber: string;
+  dongle: string;
+  beaconPosition: string;
+}
+
 export interface Owner {
   beaconOwnerFullName: string;
   beaconOwnerEmail?: string;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -8,7 +8,7 @@ const FourOhFour: FunctionComponent = (): JSX.Element => {
   const pageHeading = "Page not found";
 
   return (
-    <Layout title={pageHeading} pageHasErrors={false}>
+    <Layout title={pageHeading} pageHasErrors={false} showCookieBanner={false}>
       <Grid
         mainContent={
           <>

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -1,0 +1,252 @@
+import { GetServerSideProps } from "next";
+import React, { FunctionComponent } from "react";
+import { BackButton, Button } from "../../components/Button";
+import { FormErrorSummary } from "../../components/ErrorSummary";
+import {
+  Form,
+  FormFieldset,
+  FormGroup,
+  FormLegendPageHeading,
+} from "../../components/Form";
+import { Grid } from "../../components/Grid";
+import { FormInputProps, Input } from "../../components/Input";
+import { Layout } from "../../components/Layout";
+import { IfYouNeedHelp } from "../../components/Mca";
+import { TextareaCharacterCount } from "../../components/Textarea";
+import { FieldManager } from "../../lib/form/fieldManager";
+import { FormManager } from "../../lib/form/formManager";
+import { Validators } from "../../lib/form/validators";
+import { CacheEntry } from "../../lib/formCache";
+import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
+
+const definePageForm = ({
+  maxCapacity,
+  aircraftManufacturer,
+  principalAirport,
+  secondaryAirport,
+  registrationMark,
+  hexAddress,
+  cnOrMsnNumber,
+  dongle,
+  beaconPosition,
+}: CacheEntry): FormManager => {
+  return new FormManager({
+    maxCapacity: new FieldManager(maxCapacity, [
+      Validators.required(
+        "Maximum number of persons onboard is a required field"
+      ),
+      Validators.wholeNumber(
+        "Maximum number of persons onboard must be a whole number"
+      ),
+    ]),
+    aircraftManufacturer: new FieldManager(aircraftManufacturer),
+    principalAirport: new FieldManager(principalAirport),
+    secondaryAirport: new FieldManager(secondaryAirport),
+    registrationMark: new FieldManager(registrationMark),
+    hexAddress: new FieldManager(hexAddress),
+    cnOrMsnNumber: new FieldManager(cnOrMsnNumber),
+    dongle: new FieldManager(dongle),
+    beaconPosition: new FieldManager(beaconPosition, [
+      Validators.maxLength(
+        "Where the beacon will be positioned has too many characters",
+        100
+      ),
+    ]),
+  });
+};
+
+const AboutTheAircraft: FunctionComponent<FormPageProps> = ({
+  form,
+  showCookieBanner,
+}: FormPageProps): JSX.Element => {
+  const pageHeading = "About the aircraft";
+
+  return (
+    <>
+      <Layout
+        navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
+        title={pageHeading}
+        pageHasErrors={form.hasErrors}
+        showCookieBanner={showCookieBanner}
+      >
+        <Grid
+          mainContent={
+            <>
+              <FormErrorSummary formErrors={form.errorSummary} />
+              <Form action="/register-a-beacon/about-the-aircraft">
+                <FormFieldset>
+                  <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
+
+                  <MaxCapacityInput
+                    value={form.fields.maxCapacity.value}
+                    errorMessages={form.fields.maxCapacity.errorMessages}
+                  />
+
+                  <Manufacturer
+                    value={form.fields.aircraftManufacturer.value}
+                  />
+
+                  <PrincipalAirport
+                    value={form.fields.principalAirport.value}
+                  />
+
+                  <SecondaryAirport
+                    value={form.fields.secondaryAirport.value}
+                  />
+
+                  <RegistrationMark
+                    value={form.fields.registrationMark.value}
+                  />
+
+                  <HexAddress value={form.fields.hexAddress.value} />
+
+                  <CoreNumberOrManufacturerSerialNumber
+                    value={form.fields.cnOrMsnNumber.value}
+                  />
+
+                  <BeaconPosition
+                    value={form.fields.beaconPosition.value}
+                    errorMessages={form.fields.beaconPosition.errorMessages}
+                  />
+                </FormFieldset>
+                <Button buttonText="Continue" />
+              </Form>
+              <IfYouNeedHelp />
+            </>
+          }
+        />
+      </Layout>
+    </>
+  );
+};
+
+const MaxCapacityInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+  errorMessages,
+}: FormInputProps): JSX.Element => (
+  <FormGroup errorMessages={errorMessages}>
+    <Input
+      id="maxCapacity"
+      label="Enter the maximum number of persons onboard"
+      hintText="Knowing the maximum number of persons likely to be onboard the aircraft helps Search and Rescue know how many people to look for and what resources to send"
+      defaultValue={value}
+      numOfChars={5}
+      htmlAttributes={{
+        pattern: "[0-9]*",
+        inputMode: "numeric",
+      }}
+    />
+  </FormGroup>
+);
+
+const Manufacturer: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="aircraftManufacturer"
+      label="Aircraft manufacturer and model/type (optional)"
+      hintText="E.g. Cessna 162 Skycatcher"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const PrincipalAirport: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="principalAirport"
+      label="Principal airport or airfield (optional)"
+      hintText="E.g. Bristol International Airport"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const SecondaryAirport: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="secondaryAirport"
+      label="Secondary airport or airfield (optional)"
+      hintText="E.g. Bristol International Airport"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const RegistrationMark: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="registrationMark"
+      label="Enter the Aircraft Registration Mark (optional)"
+      hintText="This is usually found on the rear fuselage or tail E.g. G-AAAA"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const HexAddress: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="hexAddress"
+      label="Enter the Aircraft 24-bit HEXADECIMAL address (optional)"
+      hintText="The 24-bit address is used to provide a unique identity normally allocated to an individual aircraft or registration. E.g. AC82EC"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const CoreNumberOrManufacturerSerialNumber: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="cnOrMsnNumber"
+      label="Enter the Aircraft CORE Number (CN) or Manufacturers Serial Number (MSN) (optional)"
+      hintText="These help Search and Rescue positively identify aircraft if it changes aircraft registration e.g. G-WXYZ becomes M-ZYXW"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const Dongle: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="dongle"
+      label="Is the beacon a dongle? (optional)"
+      hintText="A dongle is a small USB stick beacon that can be moved between different aircraft. Knowing if it might used on a different aircraft will help Search and Rescue in an emergency"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const BeaconPosition: FunctionComponent<FormInputProps> = ({
+  value = "",
+  errorMessages,
+}: FormInputProps) => (
+  <TextareaCharacterCount
+    id="beaconPosition"
+    errorMessages={errorMessages}
+    label="Tell us where this beacon will be positioned (optional)"
+    hintText="E.g. will the beacon be attached to the pilot, stowed inside the nose of the aircraft, in the tail etc?"
+    maxCharacters={100}
+    defaultValue={value}
+  />
+);
+
+export const getServerSideProps: GetServerSideProps = handlePageRequest(
+  "/register-a-beacon/vessel-communications",
+  definePageForm
+);
+
+export default AboutTheAircraft;

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -6,12 +6,15 @@ import {
   Form,
   FormFieldset,
   FormGroup,
+  FormHint,
+  FormLegend,
   FormLegendPageHeading,
 } from "../../components/Form";
 import { Grid } from "../../components/Grid";
 import { FormInputProps, Input } from "../../components/Input";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
+import { RadioList, RadioListItem } from "../../components/RadioList";
 import { TextareaCharacterCount } from "../../components/Textarea";
 import { FieldManager } from "../../lib/form/fieldManager";
 import { FormManager } from "../../lib/form/formManager";
@@ -105,6 +108,8 @@ const AboutTheAircraft: FunctionComponent<FormPageProps> = ({
                   <CoreNumberOrManufacturerSerialNumber
                     value={form.fields.cnOrMsnNumber.value}
                   />
+
+                  <Dongle value={form.fields.dongle.value} />
 
                   <BeaconPosition
                     value={form.fields.beaconPosition.value}
@@ -223,12 +228,30 @@ const Dongle: FunctionComponent<FormInputProps> = ({
   value = "",
 }: FormInputProps): JSX.Element => (
   <FormGroup>
-    <Input
-      id="dongle"
-      label="Is the beacon a dongle? (optional)"
-      hintText="A dongle is a small USB stick beacon that can be moved between different aircraft. Knowing if it might used on a different aircraft will help Search and Rescue in an emergency"
-      defaultValue={value}
-    />
+    <FormFieldset>
+      <FormLegend>Types of communication devices onboard</FormLegend>
+      <FormHint forId="typesOfCommunication">
+        A dongle is a small USB stick beacon that can be moved between different
+        aircraft. Knowing if it might used on a different aircraft will help
+        Search and Rescue in an emergency
+      </FormHint>
+      <RadioList small={true}>
+        <RadioListItem
+          id="dongle-no"
+          name="dongle"
+          value="false"
+          label="no"
+          defaultChecked={value === "false"}
+        />
+        <RadioListItem
+          id="dongle-yes"
+          name="dongle"
+          value="true"
+          label="yes"
+          defaultChecked={value === "true"}
+        />
+      </RadioList>
+    </FormFieldset>
   </FormGroup>
 );
 

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -20,7 +20,7 @@ import { CacheEntry } from "../../lib/formCache";
 import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
 
 const definePageForm = ({
-  maxCapacity,
+  aircraftMaxCapacity,
   aircraftManufacturer,
   principalAirport,
   secondaryAirport,
@@ -31,7 +31,7 @@ const definePageForm = ({
   beaconPosition,
 }: CacheEntry): FormManager => {
   return new FormManager({
-    maxCapacity: new FieldManager(maxCapacity, [
+    aircraftMaxCapacity: new FieldManager(aircraftMaxCapacity, [
       Validators.required(
         "Maximum number of persons onboard is a required field"
       ),
@@ -78,8 +78,10 @@ const AboutTheAircraft: FunctionComponent<FormPageProps> = ({
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
 
                   <MaxCapacityInput
-                    value={form.fields.maxCapacity.value}
-                    errorMessages={form.fields.maxCapacity.errorMessages}
+                    value={form.fields.aircraftMaxCapacity.value}
+                    errorMessages={
+                      form.fields.aircraftMaxCapacity.errorMessages
+                    }
                   />
 
                   <Manufacturer
@@ -126,7 +128,7 @@ const MaxCapacityInput: FunctionComponent<FormInputProps> = ({
 }: FormInputProps): JSX.Element => (
   <FormGroup errorMessages={errorMessages}>
     <Input
-      id="maxCapacity"
+      id="aircraftMaxCapacity"
       label="Enter the maximum number of persons onboard"
       hintText="Knowing the maximum number of persons likely to be onboard the aircraft helps Search and Rescue know how many people to look for and what resources to send"
       defaultValue={value}
@@ -245,7 +247,7 @@ const BeaconPosition: FunctionComponent<FormInputProps> = ({
 );
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/vessel-communications",
+  "/register-a-beacon/aircraft-communications",
   definePageForm
 );
 

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -155,33 +155,31 @@ const AreaOfOperationTextArea: FunctionComponent<FormInputProps> = ({
   value = "",
   errorMessages,
 }: FormInputProps): JSX.Element => (
-  <FormGroup errorMessages={errorMessages}>
-    <TextareaCharacterCount
-      id="areaOfOperation"
-      label="Tell us about the typical area of operation (optional)"
-      hintText="Typical areas of operation for the vessel is very helpful in assisting Search and Rescue. For example 'Whitesands Bay, St Davids, Pembrokeshire'"
-      defaultValue={value}
-      maxCharacters={250}
-      rows={4}
-    />
-  </FormGroup>
+  <TextareaCharacterCount
+    id="areaOfOperation"
+    label="Tell us about the typical area of operation (optional)"
+    hintText="Typical areas of operation for the vessel is very helpful in assisting Search and Rescue. For example 'Whitesands Bay, St Davids, Pembrokeshire'"
+    defaultValue={value}
+    errorMessages={errorMessages}
+    maxCharacters={250}
+    rows={4}
+  />
 );
 
 const BeaconLocationInput: FunctionComponent<FormInputProps> = ({
   value = "",
   errorMessages,
 }: FormInputProps): JSX.Element => (
-  <FormGroup errorMessages={errorMessages}>
-    <TextareaCharacterCount
-      id="beaconLocation"
-      label="Tell us where this beacon will be kept (optional)"
-      hintText="E.g. will the beacon be attached to a life jacket, stowed inside the
+  <TextareaCharacterCount
+    id="beaconLocation"
+    label="Tell us where this beacon will be kept (optional)"
+    hintText="E.g. will the beacon be attached to a life jacket, stowed inside the
     cabin, in a grab bag etc?"
-      defaultValue={value}
-      maxCharacters={100}
-      rows={3}
-    />
-  </FormGroup>
+    defaultValue={value}
+    errorMessages={errorMessages}
+    maxCharacters={100}
+    rows={3}
+  />
 );
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(

--- a/src/pages/register-a-beacon/emergency-contact.tsx
+++ b/src/pages/register-a-beacon/emergency-contact.tsx
@@ -178,7 +178,7 @@ const EmergencyContactGroup: FunctionComponent<EmergencyContactGroupProps> = ({
   telephoneNumberErrorMessages,
 }: EmergencyContactGroupProps): JSX.Element => (
   <>
-    <FormLegend className="govuk-fieldset__legend--m">
+    <FormLegend size="medium">
       Emergency contact {index}
       {index == "1" ? "" : " (optional)"}
     </FormLegend>

--- a/src/pages/register-a-beacon/more-vessel-details.tsx
+++ b/src/pages/register-a-beacon/more-vessel-details.tsx
@@ -5,7 +5,6 @@ import { FormErrorSummary } from "../../components/ErrorSummary";
 import {
   Form,
   FormFieldset,
-  FormGroup,
   FormLegendPageHeading,
 } from "../../components/Form";
 import { Grid } from "../../components/Grid";
@@ -79,18 +78,17 @@ const MoreVesselDetailsTextArea: FunctionComponent<MoreVesselDetailsTextAreaProp
   value = "",
   errorMessages,
 }: MoreVesselDetailsTextAreaProps): JSX.Element => (
-  <FormGroup errorMessages={errorMessages}>
-    <TextareaCharacterCount
-      id="moreVesselDetails"
-      hintText="Describe the vessel's appearance (such as the length, colour, if it
+  <TextareaCharacterCount
+    id="moreVesselDetails"
+    hintText="Describe the vessel's appearance (such as the length, colour, if it
         has sails or not etc) and any vessel tracking details (e.g. RYA SafeTrx
         or Web) if you have them. This information is very helpful to Search
         and Rescue when trying to locate you."
-      maxCharacters={250}
-      rows={4}
-      defaultValue={value}
-    />
-  </FormGroup>
+    maxCharacters={250}
+    rows={4}
+    defaultValue={value}
+    errorMessages={errorMessages}
+  />
 );
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(

--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -201,7 +201,7 @@ const TypesOfCommunication: FunctionComponent<FormPageProps> = ({
   form,
 }: FormPageProps) => (
   <FormFieldset>
-    <FormLegend className="govuk-fieldset__legend--s">
+    <FormLegend size="small">
       Types of communication devices onboard
       <FormHint forId="typesOfCommunication">
         Tick all that apply and provide as much detail as you can

--- a/test/components/Textarea.test.tsx
+++ b/test/components/Textarea.test.tsx
@@ -53,5 +53,19 @@ describe("Textarea Components", () => {
       );
       expect(screen.getByText(hintText)).toBeDefined();
     });
+
+    it("should render the error messages if provided", () => {
+      const errorMessage =
+        "Where the beacon is positioned must be less than 100 characters";
+      render(
+        <TextareaCharacterCount
+          id={id}
+          label={label}
+          maxCharacters={100}
+          errorMessages={[errorMessage]}
+        />
+      );
+      expect(screen.getByText(errorMessage)).toBeDefined();
+    });
   });
 });

--- a/test/pages/register-a-beacon/about-the-aircraft.test.tsx
+++ b/test/pages/register-a-beacon/about-the-aircraft.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { FormJSON } from "../../../src/lib/form/formManager";
+import AboutTheAircraft from "../../../src/pages/register-a-beacon/about-the-aircraft";
+
+describe("AboutTheAircraft", () => {
+  const aboutTheAircraftForm: FormJSON = {
+    hasErrors: false,
+    errorSummary: [],
+    fields: {
+      aircraftMaxCapacity: {
+        value: "",
+        errorMessages: [],
+      },
+      aircraftManufacturer: {
+        value: "",
+        errorMessages: [],
+      },
+      principalAirport: {
+        value: "",
+        errorMessages: [],
+      },
+      registrationMark: {
+        value: "",
+        errorMessages: [],
+      },
+      hexAddress: {
+        value: "",
+        errorMessages: [],
+      },
+      cnOrMsnNumber: {
+        value: "",
+        errorMessages: [],
+      },
+      dongle: {
+        value: "",
+        errorMessages: [],
+      },
+      beaconPosition: {
+        value: "",
+        errorMessages: [],
+      },
+    },
+  };
+
+  it("renders the page", () => {
+    render(<AboutTheAircraft form={aboutTheAircraftForm} />);
+  });
+});

--- a/test/pages/register-a-beacon/about-the-aircraft.test.tsx
+++ b/test/pages/register-a-beacon/about-the-aircraft.test.tsx
@@ -20,6 +20,10 @@ describe("AboutTheAircraft", () => {
         value: "",
         errorMessages: [],
       },
+      secondaryAirport: {
+        value: "",
+        errorMessages: [],
+      },
       registrationMark: {
         value: "",
         errorMessages: [],

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -13,7 +13,7 @@ jest.mock("../../../src/lib/handlePageRequest", () => ({
 }));
 
 describe("AboutTheVessel", () => {
-  const emptyPrimaryBeaconUseForm: FormJSON = {
+  const aboutTheVesselForm: FormJSON = {
     hasErrors: false,
     errorSummary: [],
     fields: {
@@ -41,7 +41,7 @@ describe("AboutTheVessel", () => {
   };
 
   it("should have a back button which directs the user to the primary beacon use page", () => {
-    render(<AboutTheVessel form={emptyPrimaryBeaconUseForm} />);
+    render(<AboutTheVessel form={aboutTheVesselForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
@@ -50,9 +50,7 @@ describe("AboutTheVessel", () => {
   });
 
   it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const { container } = render(
-      <AboutTheVessel form={emptyPrimaryBeaconUseForm} />
-    );
+    const { container } = render(<AboutTheVessel form={aboutTheVesselForm} />);
     const ownPath = "/register-a-beacon/about-the-vessel";
 
     const form = container.querySelectorAll("form")[1];

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -40,7 +40,7 @@ describe("AboutTheVessel", () => {
     },
   };
 
-  it("should have a back button which directs the user to the primary beacon use page", () => {
+  it("should have a back button which directs the user to the about the vessel page", () => {
     render(<AboutTheVessel form={aboutTheVesselForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(


### PR DESCRIPTION
## Context

- Adds about the aircraft page
- Link to next page goes to `/register-a-beacon/aircraft-communications` which has not yet been implemented but have added a Cypress test to check this
- Previous page goes to `/register-a-beacon/primary-beacon-use`.  This page may be updated later, but I have added a Cypress test to check the page URL incase that changes

## Changes in this pull request

- Adds about the aircraft page
- I have also removed the cookie banner on the 404 page as a 404 page has to be statically generated. This means that we cannot determine whether the user has accepted the cookie policy or not.  Decision to not show this even if they haven't accepted is a better solution vs showing it if they have

## Link to Trello card

- https://trello.com/c/8SFo0HYq/290-create-about-the-aircraft-page

## Things to check

- [ ] Environment variables have been updated


Aircraft page:

![image](https://user-images.githubusercontent.com/76042279/111784003-c7a57e00-88b2-11eb-95e4-d6b13bf3d2ac.png)
![image](https://user-images.githubusercontent.com/76042279/111784042-d2f8a980-88b2-11eb-841c-732d72c193f5.png)
