### PR TITLE
Update the about vessel page

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,9 +48,14 @@ export interface BeaconInformation {
 export interface Vessel {
   maxCapacity: string;
   vesselName: string;
+  beaconLocation: string;
+  pln: string;
   homeport: string;
   areaOfOperation: string;
-  beaconLocation: string;
+  imoNumber: string;
+  ssrNumber: string;
+  officialNumber: string;
+  rigPlatformLocation: string;
   moreDetails: string;
   maritimePleasureVesselUse: string;
   otherPleasureVesselText: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,7 +49,7 @@ export interface Vessel {
   maxCapacity: string;
   vesselName: string;
   beaconLocation: string;
-  pln: string;
+  portLetterNumber: string;
   homeport: string;
   areaOfOperation: string;
   imoNumber: string;

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../components/Form";
 import { Grid } from "../../components/Grid";
 import { FormInputProps, Input } from "../../components/Input";
+import { InsetText } from "../../components/InsetText";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { TextareaCharacterCount } from "../../components/Textarea";
@@ -23,9 +24,14 @@ import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
 const definePageForm = ({
   maxCapacity,
   vesselName,
+  beaconLocation,
+  pln,
   homeport,
   areaOfOperation,
-  beaconLocation,
+  imoNumber,
+  ssrNumber,
+  officialNumber,
+  rigPlatformLocation,
 }: CacheEntry): FormManager => {
   return new FormManager({
     maxCapacity: new FieldManager(maxCapacity, [
@@ -37,6 +43,13 @@ const definePageForm = ({
       ),
     ]),
     vesselName: new FieldManager(vesselName),
+    beaconLocation: new FieldManager(beaconLocation, [
+      Validators.maxLength(
+        "Where the beacon is kept has too many characters",
+        100
+      ),
+    ]),
+    pln: new FieldManager(pln),
     homeport: new FieldManager(homeport),
     areaOfOperation: new FieldManager(areaOfOperation, [
       Validators.maxLength(
@@ -44,12 +57,10 @@ const definePageForm = ({
         250
       ),
     ]),
-    beaconLocation: new FieldManager(beaconLocation, [
-      Validators.maxLength(
-        "Where the beacon is kept has too many characters",
-        100
-      ),
-    ]),
+    imoNumber: new FieldManager(imoNumber),
+    ssrNumber: new FieldManager(ssrNumber),
+    officialNumber: new FieldManager(officialNumber),
+    rigPlatformLocation: new FieldManager(rigPlatformLocation),
   });
 };
 
@@ -75,6 +86,12 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
 
+                  <InsetText>
+                    Leave anything that isn't relevant blank. Any information
+                    you do provide may help save lives in a Search & Rescue
+                    scenario.
+                  </InsetText>
+
                   <MaxCapacityInput
                     value={form.fields.maxCapacity.value}
                     errorMessages={form.fields.maxCapacity.errorMessages}
@@ -89,14 +106,29 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
 
                   <SectionHeading>Vessel information</SectionHeading>
 
-                  <HomeportInput
-                    value={form.fields.homeport.value}
-                    errorMessages={form.fields.areaOfOperation.errorMessages}
-                  />
+                  <PlnInput value={form.fields.pln.value} />
+
+                  <HomeportInput value={form.fields.homeport.value} />
 
                   <AreaOfOperationTextArea
                     value={form.fields.areaOfOperation.value}
                     errorMessages={form.fields.areaOfOperation.errorMessages}
+                  />
+
+                  <ImoNumberInput value={form.fields.imoNumber.value} />
+
+                  <SsrNumberInput value={form.fields.ssrNumber.value} />
+
+                  <OfficialNumberInput
+                    value={form.fields.officialNumber.value}
+                  />
+
+                  <SectionHeading>
+                    Windfarm, rig or platform information
+                  </SectionHeading>
+
+                  <RigPlatformLocationInput
+                    value={form.fields.rigPlatformLocation.value}
                   />
                 </FormFieldset>
                 <Button buttonText="Continue" />
@@ -141,6 +173,19 @@ const VesselNameInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
+const PlnInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="pln"
+      label="If you have one, enter the Port Letter & Number or PLN (optional)"
+      hintText="This is a code identifying fishing vessels, usually printed on the boat. The format is XYZ123"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
 const HomeportInput: FunctionComponent<FormInputProps> = ({
   value = "",
 }: FormInputProps): JSX.Element => (
@@ -167,6 +212,59 @@ const AreaOfOperationTextArea: FunctionComponent<FormInputProps> = ({
     maxCharacters={250}
     rows={4}
   />
+);
+
+const ImoNumberInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="imoNumber"
+      label="If you have one, enter the IMO number (optional)"
+      hintText="An IMO number is made of the three letters 'IMO' followed by a seven-digit number."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const SsrNumberInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="ssrNumber"
+      label="If you have one, enter the UK Small Ships Register (SSR)  number (optional)"
+      /*TODO update with SSR number format*/
+      hintText="Hint text for format"
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const OfficialNumberInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="officialNumber"
+      label="If you have one, enter vessel's official number (optional)"
+      hintText="Official numbers are ship identifier numbers assigned to merchant ships by their country or registration."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const RigPlatformLocationInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="rigPlatformLocation"
+      label="Where is the rig or platform located? (optional)"
+      hintText="You can enter a place or area name, area or latitude/longitude co-ordinates"
+      defaultValue={value}
+    />
+  </FormGroup>
 );
 
 const BeaconLocationInput: FunctionComponent<FormInputProps> = ({

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -13,6 +13,7 @@ import { FormInputProps, Input } from "../../components/Input";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { TextareaCharacterCount } from "../../components/Textarea";
+import { SectionHeading } from "../../components/Typography";
 import { FieldManager } from "../../lib/form/fieldManager";
 import { FormManager } from "../../lib/form/formManager";
 import { Validators } from "../../lib/form/validators";
@@ -81,6 +82,13 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
 
                   <VesselNameInput value={form.fields.vesselName.value} />
 
+                  <BeaconLocationInput
+                    value={form.fields.beaconLocation.value}
+                    errorMessages={form.fields.beaconLocation.errorMessages}
+                  />
+
+                  <SectionHeading>Vessel information</SectionHeading>
+
                   <HomeportInput
                     value={form.fields.homeport.value}
                     errorMessages={form.fields.areaOfOperation.errorMessages}
@@ -89,11 +97,6 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
                   <AreaOfOperationTextArea
                     value={form.fields.areaOfOperation.value}
                     errorMessages={form.fields.areaOfOperation.errorMessages}
-                  />
-
-                  <BeaconLocationInput
-                    value={form.fields.beaconLocation.value}
-                    errorMessages={form.fields.beaconLocation.errorMessages}
                   />
                 </FormFieldset>
                 <Button buttonText="Continue" />

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -87,9 +87,9 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
 
                   <InsetText>
-                    Leave anything that isn't relevant blank. Any information
-                    you do provide may help save lives in a Search & Rescue
-                    scenario.
+                    Leave anything that isn&apos;t relevant blank. Any
+                    information you do provide may help save lives in a Search &
+                    Rescue scenario.
                   </InsetText>
 
                   <MaxCapacityInput

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -56,7 +56,7 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
   form,
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
-  const pageHeading = "About the pleasure vessel";
+  const pageHeading = "About the vessel, windfarm or rig/platform";
 
   return (
     <>
@@ -115,7 +115,7 @@ const MaxCapacityInput: FunctionComponent<FormInputProps> = ({
     <Input
       id="maxCapacity"
       label="Enter the maximum number of persons onboard"
-      hintText="Knowing the maximum number of persons likely to be onboard the vessel helps Search and Rescue know how many people to look for and what resources to send"
+      hintText="This helps Search and Rescue know how many people to look for and what resources to send"
       defaultValue={value}
       numOfChars={5}
       htmlAttributes={{
@@ -132,7 +132,7 @@ const VesselNameInput: FunctionComponent<FormInputProps> = ({
   <FormGroup>
     <Input
       id="vesselName"
-      label="Enter your vessel name (optional)"
+      label="Enter your vessel, windfarm or rig/platform name (optional)"
       defaultValue={value}
     />
   </FormGroup>
@@ -158,7 +158,7 @@ const AreaOfOperationTextArea: FunctionComponent<FormInputProps> = ({
   <TextareaCharacterCount
     id="areaOfOperation"
     label="Tell us about the typical area of operation (optional)"
-    hintText="Typical areas of operation for the vessel is very helpful in assisting Search and Rescue. For example 'Whitesands Bay, St Davids, Pembrokeshire'"
+    hintText="This is very helpful in assisting Search & Rescue. For example 'Whitesands Bay, St Davids, Pembrokeshire'"
     defaultValue={value}
     errorMessages={errorMessages}
     maxCharacters={250}

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -25,7 +25,7 @@ const definePageForm = ({
   maxCapacity,
   vesselName,
   beaconLocation,
-  pln,
+  portLetterNumber,
   homeport,
   areaOfOperation,
   imoNumber,
@@ -49,7 +49,7 @@ const definePageForm = ({
         100
       ),
     ]),
-    pln: new FieldManager(pln),
+    portLetterNumber: new FieldManager(portLetterNumber),
     homeport: new FieldManager(homeport),
     areaOfOperation: new FieldManager(areaOfOperation, [
       Validators.maxLength(
@@ -106,7 +106,9 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
 
                   <SectionHeading>Vessel information</SectionHeading>
 
-                  <PlnInput value={form.fields.pln.value} />
+                  <PortLetterNumberInput
+                    value={form.fields.portLetterNumber.value}
+                  />
 
                   <HomeportInput value={form.fields.homeport.value} />
 
@@ -173,12 +175,12 @@ const VesselNameInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
-const PlnInput: FunctionComponent<FormInputProps> = ({
+const PortLetterNumberInput: FunctionComponent<FormInputProps> = ({
   value = "",
 }: FormInputProps): JSX.Element => (
   <FormGroup>
     <Input
-      id="pln"
+      id="portLetterNumber"
       label="If you have one, enter the Port Letter & Number or PLN (optional)"
       hintText="This is a code identifying fishing vessels, usually printed on the boat. The format is XYZ123"
       defaultValue={value}

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -25,6 +25,14 @@ describe("AboutTheVessel", () => {
         value: "",
         errorMessages: [],
       },
+      beaconLocation: {
+        value: "",
+        errorMessages: [],
+      },
+      pln: {
+        value: "",
+        errorMessages: [],
+      },
       homeport: {
         value: "",
         errorMessages: [],
@@ -33,7 +41,19 @@ describe("AboutTheVessel", () => {
         value: "",
         errorMessages: [],
       },
-      beaconLocation: {
+      imoNumber: {
+        value: "",
+        errorMessages: [],
+      },
+      ssrNumber: {
+        value: "",
+        errorMessages: [],
+      },
+      officialNumber: {
+        value: "",
+        errorMessages: [],
+      },
+      rigPlatformLocation: {
         value: "",
         errorMessages: [],
       },

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -29,7 +29,7 @@ describe("AboutTheVessel", () => {
         value: "",
         errorMessages: [],
       },
-      pln: {
+      portLetterNumber: {
         value: "",
         errorMessages: [],
       },


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
This is the first slice 🍰 for updating the About the Vessel page (`/register-a-beacon/about-the-vessel`)

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Amend the `Vessel` type to take in new fields
- Add new inputs on the page according to the [wireframe](https://miro.com/app/board/o9J_lZuM9qs=/?moveToWidget=3074457354940416299&cot=10)

What the page looks like now:
<img width=500 src='https://user-images.githubusercontent.com/32230328/112019900-cdf06000-8b27-11eb-930c-32bbd1061833.png'></img>

**To do**
- Get SSR number format and update `hint text` for the input
- Link to L3 page when that's ready
- Check if we need to validate any of the new fields:
   - E.g. `IMO number is made of the three letters 'IMO' followed by a seven-digit number`
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
This is a fairly small change, but would love some feedback on field names if they don't sound right.
- E.g. is `pln` okay for Port letter and number?
## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/bymaQwO8/289-update-about-the-vessel-page

