### PR TITLE
Primary beacon use -> Activity - first slice 🍰 

### DIFF
--- a/cypress/integration/aboutTheAircraft.spec.ts
+++ b/cypress/integration/aboutTheAircraft.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./common.spec";
 
 describe("As a beacon owner, I want to submit information about my aircraft", () => {
-  const previousPageUrl = "/register-a-beacon/primary-beacon-use";
+  const previousPageUrl = "/register-a-beacon/activity";
   const thisPageUrl = "/register-a-beacon/about-the-aircraft";
   const nextPageUrl = "/register-a-beacon/aircraft-communications";
 

--- a/cypress/integration/activity.spec.ts
+++ b/cypress/integration/activity.spec.ts
@@ -12,8 +12,8 @@ import {
   whenIType,
 } from "./common.spec";
 
-describe("As a beacon owner, I want to submit the primary use for my beacon", () => {
-  const thisPageUrl = "/register-a-beacon/primary-beacon-use";
+describe("As a beacon owner, I want to submit the primary activity for my beacon", () => {
+  const thisPageUrl = "/register-a-beacon/activity";
   const previousPageUrl = "/register-a-beacon/beacon-information";
 
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
     iCanClickTheBackLinkToGoToPreviousPage(previousPageUrl);
   });
 
-  it("displays an error if no primary beacon use is selected", () => {
+  it("displays an error if no activity is selected", () => {
     whenIClickContinue();
     thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
     thenIShouldSeeAnErrorSummaryLinkThatContains(
@@ -46,7 +46,7 @@ describe("As a beacon owner, I want to submit the primary use for my beacon", ()
     thenMyFocusMovesTo("#motor-vessel");
   });
 
-  it("routes to the next page if there are no errors with the selected primary beacon use", () => {
+  it("routes to the next page if there are no errors with the selected activity", () => {
     givenIHaveSelected("#motor-vessel");
     whenIClickContinue();
 

--- a/cypress/integration/beaconInformation.spec.ts
+++ b/cypress/integration/beaconInformation.spec.ts
@@ -40,7 +40,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
     whenIType("ASOS", manufacturerSerialNumberFieldSelector);
     whenIClickContinue();
 
-    thenTheUrlShouldContain("/register-a-beacon/primary-beacon-use");
+    thenTheUrlShouldContain("/register-a-beacon/activity");
   });
 
   describe("the manufacturer serial number field", () => {

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -67,7 +67,7 @@ const AboutTheAircraft: FunctionComponent<FormPageProps> = ({
   return (
     <>
       <Layout
-        navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
+        navigation={<BackButton href="/register-a-beacon/activity" />}
         title={pageHeading}
         pageHasErrors={form.hasErrors}
         showCookieBanner={showCookieBanner}

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -73,7 +73,7 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
   return (
     <>
       <Layout
-        navigation={<BackButton href="/register-a-beacon/primary-beacon-use" />}
+        navigation={<BackButton href="/register-a-beacon/activity" />}
         title={pageHeading}
         pageHasErrors={form.hasErrors}
         showCookieBanner={showCookieBanner}

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -45,7 +45,7 @@ const Activity: FunctionComponent<FormPageProps> = ({
 
   return (
     <BeaconsForm
-      previousPageUrl={"/register-a-beacon/beacon-information"}
+      previousPageUrl="/register-a-beacon/beacon-information"
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
       formErrors={form.errorSummary}
@@ -97,7 +97,7 @@ const MaritimePleasureOptions: FunctionComponent<OptionsProps> = ({
         }
       />
       <RadioListItem
-        id="maritimePleasureVesselUse"
+        id="small-unpowered-vessel"
         value={MaritimePleasureVessel.SMALL_UNPOWERED}
         label="Small unpowered vessel"
         hintText="E.g. Canoe, Kayak"

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -36,7 +36,7 @@ const definePageForm = ({
   });
 };
 
-const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
+const Activity: FunctionComponent<FormPageProps> = ({
   form,
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
@@ -137,4 +137,4 @@ export const getServerSideProps: GetServerSideProps = handlePageRequest(
   definePageForm
 );
 
-export default PrimaryBeaconUse;
+export default Activity;

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -284,7 +284,7 @@ const transformFormData = (formData: CacheEntry): CacheEntry => {
 };
 
 export const getServerSideProps: GetServerSideProps = handlePageRequest(
-  "/register-a-beacon/primary-beacon-use",
+  "/register-a-beacon/activity",
   definePageForm,
   transformFormData
 );

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -173,8 +173,8 @@ const BeaconUseSection: FunctionComponent<CacheEntry> = ({
 
       <SummaryList>
         <SummaryListItem
-          labelText="Primary use of beacon"
-          href="/register-a-beacon/primary-beacon-use"
+          labelText="Primary beacon activity"
+          href="/register-a-beacon/activity"
           actionText="Change"
         >
           {"Maritime"}

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -1,17 +1,8 @@
 import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
-import { BackButton, Button } from "../../components/Button";
-import { FormErrorSummary } from "../../components/ErrorSummary";
-import {
-  Form,
-  FormFieldset,
-  FormGroup,
-  FormLegendPageHeading,
-} from "../../components/Form";
-import { Grid } from "../../components/Grid";
+import { BeaconsForm } from "../../components/BeaconsForm";
+import { FormGroup } from "../../components/Form";
 import { Input } from "../../components/Input";
-import { Layout } from "../../components/Layout";
-import { IfYouNeedHelp } from "../../components/Mca";
 import { RadioList, RadioListItem } from "../../components/RadioList";
 import { FieldManager } from "../../lib/form/fieldManager";
 import { FormManager } from "../../lib/form/formManager";
@@ -46,111 +37,85 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
   const maritimePleasureVesselName = "maritimePleasureVesselUse";
+  const pageHeading =
+    "What type of maritime pleasure vessel will you mostly use this beacon on?";
 
   return (
-    <Layout
-      title={
-        "What type of maritime pleasure vessel will you mostly use this beacon on?"
-      }
-      navigation={<BackButton href="/register-a-beacon/beacon-information" />}
-      pageHasErrors={form.hasErrors}
+    <BeaconsForm
+      previousPageUrl={"/register-a-beacon/beacon-information"}
+      pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
+      formErrors={form.errorSummary}
+      errorMessages={form.fields.maritimePleasureVesselUse.errorMessages}
     >
-      <Grid
-        mainContent={
-          <>
-            <FormErrorSummary formErrors={form.errorSummary} />
-            <Form action="/register-a-beacon/primary-beacon-use">
-              <FormGroup
-                errorMessages={
-                  form.fields.maritimePleasureVesselUse.errorMessages
-                }
-              >
-                <FormFieldset>
-                  <FormLegendPageHeading>
-                    What type of maritime pleasure vessel will you mostly use
-                    this beacon on?
-                  </FormLegendPageHeading>
-                </FormFieldset>
-                <RadioList conditional={true}>
-                  <RadioListItem
-                    id="motor-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.MOTOR}
-                    label="Motor vessel"
-                    hintText="E.g. Speedboat, RIB"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.MOTOR
-                    }
-                  />
-                  <RadioListItem
-                    id="sailing-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.SAILING}
-                    label="Sailing vessel"
-                    hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.SAILING
-                    }
-                  />
-                  <RadioListItem
-                    id="rowing-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.ROWING}
-                    label="Rowing vessel"
-                    hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.ROWING
-                    }
-                  />
-                  <RadioListItem
-                    id="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.SMALL_UNPOWERED}
-                    label="Small unpowered vessel"
-                    hintText="E.g. Canoe, Kayak"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.SMALL_UNPOWERED
-                    }
-                  />
-                  <RadioListItem
-                    id="other-pleasure-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.OTHER}
-                    label="Other pleasure vessel"
-                    hintText="E.g. Surfboard, Kitesurfing"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.OTHER
-                    }
-                    conditional={true}
-                  >
-                    <FormGroup
-                      errorMessages={
-                        form.fields.otherPleasureVesselText.errorMessages
-                      }
-                    >
-                      <Input
-                        id="otherPleasureVesselText"
-                        label="What sort of vessel is it?"
-                        defaultValue={form.fields.otherPleasureVesselText.value}
-                      />
-                    </FormGroup>
-                  </RadioListItem>
-                </RadioList>
-              </FormGroup>
-
-              <Button buttonText="Continue" />
-            </Form>
-
-            <IfYouNeedHelp />
-          </>
-        }
-      />
-    </Layout>
+      <RadioList conditional={true}>
+        <RadioListItem
+          id="motor-vessel"
+          name={maritimePleasureVesselName}
+          value={MaritimePleasureVessel.MOTOR}
+          label="Motor vessel"
+          hintText="E.g. Speedboat, RIB"
+          defaultChecked={
+            form.fields.maritimePleasureVesselUse.value ===
+            MaritimePleasureVessel.MOTOR
+          }
+        />
+        <RadioListItem
+          id="sailing-vessel"
+          name={maritimePleasureVesselName}
+          value={MaritimePleasureVessel.SAILING}
+          label="Sailing vessel"
+          hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+          defaultChecked={
+            form.fields.maritimePleasureVesselUse.value ===
+            MaritimePleasureVessel.SAILING
+          }
+        />
+        <RadioListItem
+          id="rowing-vessel"
+          name={maritimePleasureVesselName}
+          value={MaritimePleasureVessel.ROWING}
+          label="Rowing vessel"
+          hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+          defaultChecked={
+            form.fields.maritimePleasureVesselUse.value ===
+            MaritimePleasureVessel.ROWING
+          }
+        />
+        <RadioListItem
+          id="maritimePleasureVesselUse"
+          value={MaritimePleasureVessel.SMALL_UNPOWERED}
+          label="Small unpowered vessel"
+          hintText="E.g. Canoe, Kayak"
+          defaultChecked={
+            form.fields.maritimePleasureVesselUse.value ===
+            MaritimePleasureVessel.SMALL_UNPOWERED
+          }
+        />
+        <RadioListItem
+          id="other-pleasure-vessel"
+          name={maritimePleasureVesselName}
+          value={MaritimePleasureVessel.OTHER}
+          label="Other pleasure vessel"
+          hintText="E.g. Surfboard, Kitesurfing"
+          defaultChecked={
+            form.fields.maritimePleasureVesselUse.value ===
+            MaritimePleasureVessel.OTHER
+          }
+          conditional={true}
+        >
+          <FormGroup
+            errorMessages={form.fields.otherPleasureVesselText.errorMessages}
+          >
+            <Input
+              id="otherPleasureVesselText"
+              label="What sort of vessel is it?"
+              defaultValue={form.fields.otherPleasureVesselText.value}
+            />
+          </FormGroup>
+        </RadioListItem>
+      </RadioList>
+    </BeaconsForm>
   );
 };
 

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -5,11 +5,15 @@ import { FormGroup } from "../../components/Form";
 import { Input } from "../../components/Input";
 import { RadioList, RadioListItem } from "../../components/RadioList";
 import { FieldManager } from "../../lib/form/fieldManager";
-import { FormManager } from "../../lib/form/formManager";
+import { FormJSON, FormManager } from "../../lib/form/formManager";
 import { Validators } from "../../lib/form/validators";
 import { CacheEntry } from "../../lib/formCache";
 import { FormPageProps, handlePageRequest } from "../../lib/handlePageRequest";
 import { MaritimePleasureVessel } from "../../lib/types";
+
+interface OptionsProps {
+  form: FormJSON;
+}
 
 const definePageForm = ({
   maritimePleasureVesselUse,
@@ -36,7 +40,6 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
   form,
   showCookieBanner,
 }: FormPageProps): JSX.Element => {
-  const maritimePleasureVesselName = "maritimePleasureVesselUse";
   const pageHeading =
     "What type of maritime pleasure vessel will you mostly use this beacon on?";
 
@@ -48,74 +51,84 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
       formErrors={form.errorSummary}
       errorMessages={form.fields.maritimePleasureVesselUse.errorMessages}
     >
-      <RadioList conditional={true}>
-        <RadioListItem
-          id="motor-vessel"
-          name={maritimePleasureVesselName}
-          value={MaritimePleasureVessel.MOTOR}
-          label="Motor vessel"
-          hintText="E.g. Speedboat, RIB"
-          defaultChecked={
-            form.fields.maritimePleasureVesselUse.value ===
-            MaritimePleasureVessel.MOTOR
-          }
-        />
-        <RadioListItem
-          id="sailing-vessel"
-          name={maritimePleasureVesselName}
-          value={MaritimePleasureVessel.SAILING}
-          label="Sailing vessel"
-          hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-          defaultChecked={
-            form.fields.maritimePleasureVesselUse.value ===
-            MaritimePleasureVessel.SAILING
-          }
-        />
-        <RadioListItem
-          id="rowing-vessel"
-          name={maritimePleasureVesselName}
-          value={MaritimePleasureVessel.ROWING}
-          label="Rowing vessel"
-          hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-          defaultChecked={
-            form.fields.maritimePleasureVesselUse.value ===
-            MaritimePleasureVessel.ROWING
-          }
-        />
-        <RadioListItem
-          id="maritimePleasureVesselUse"
-          value={MaritimePleasureVessel.SMALL_UNPOWERED}
-          label="Small unpowered vessel"
-          hintText="E.g. Canoe, Kayak"
-          defaultChecked={
-            form.fields.maritimePleasureVesselUse.value ===
-            MaritimePleasureVessel.SMALL_UNPOWERED
-          }
-        />
-        <RadioListItem
-          id="other-pleasure-vessel"
-          name={maritimePleasureVesselName}
-          value={MaritimePleasureVessel.OTHER}
-          label="Other pleasure vessel"
-          hintText="E.g. Surfboard, Kitesurfing"
-          defaultChecked={
-            form.fields.maritimePleasureVesselUse.value ===
-            MaritimePleasureVessel.OTHER
-          }
-          conditional={true}
-        >
-          <FormGroup
-            errorMessages={form.fields.otherPleasureVesselText.errorMessages}
-          >
-            <Input
-              id="otherPleasureVesselText"
-              label="What sort of vessel is it?"
-              defaultValue={form.fields.otherPleasureVesselText.value}
-            />
-          </FormGroup>
-        </RadioListItem>
-      </RadioList>
+      <MaritimePleasureOptions form={form} />
     </BeaconsForm>
+  );
+};
+
+const MaritimePleasureOptions: FunctionComponent<OptionsProps> = ({
+  form,
+}: OptionsProps): JSX.Element => {
+  const maritimePleasureVesselName = "maritimePleasureVesselUse";
+
+  return (
+    <RadioList conditional={true}>
+      <RadioListItem
+        id="motor-vessel"
+        name={maritimePleasureVesselName}
+        value={MaritimePleasureVessel.MOTOR}
+        label="Motor vessel"
+        hintText="E.g. Speedboat, RIB"
+        defaultChecked={
+          form.fields.maritimePleasureVesselUse.value ===
+          MaritimePleasureVessel.MOTOR
+        }
+      />
+      <RadioListItem
+        id="sailing-vessel"
+        name={maritimePleasureVesselName}
+        value={MaritimePleasureVessel.SAILING}
+        label="Sailing vessel"
+        hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+        defaultChecked={
+          form.fields.maritimePleasureVesselUse.value ===
+          MaritimePleasureVessel.SAILING
+        }
+      />
+      <RadioListItem
+        id="rowing-vessel"
+        name={maritimePleasureVesselName}
+        value={MaritimePleasureVessel.ROWING}
+        label="Rowing vessel"
+        hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+        defaultChecked={
+          form.fields.maritimePleasureVesselUse.value ===
+          MaritimePleasureVessel.ROWING
+        }
+      />
+      <RadioListItem
+        id="maritimePleasureVesselUse"
+        value={MaritimePleasureVessel.SMALL_UNPOWERED}
+        label="Small unpowered vessel"
+        hintText="E.g. Canoe, Kayak"
+        defaultChecked={
+          form.fields.maritimePleasureVesselUse.value ===
+          MaritimePleasureVessel.SMALL_UNPOWERED
+        }
+      />
+      <RadioListItem
+        id="other-pleasure-vessel"
+        name={maritimePleasureVesselName}
+        value={MaritimePleasureVessel.OTHER}
+        label="Other pleasure vessel"
+        hintText="E.g. Surfboard, Kitesurfing"
+        defaultChecked={
+          form.fields.maritimePleasureVesselUse.value ===
+          MaritimePleasureVessel.OTHER
+        }
+        conditional={true}
+      >
+        <FormGroup
+          errorMessages={form.fields.otherPleasureVesselText.errorMessages}
+        >
+          <Input
+            id="otherPleasureVesselText"
+            label="What sort of vessel is it?"
+            defaultValue={form.fields.otherPleasureVesselText.value}
+          />
+        </FormGroup>
+      </RadioListItem>
+    </RadioList>
   );
 };
 

--- a/test/pages/register-a-beacon/about-beacon-owner.test.tsx
+++ b/test/pages/register-a-beacon/about-beacon-owner.test.tsx
@@ -36,7 +36,7 @@ describe("AboutBeaconOwner", () => {
     },
   };
 
-  it("should have a back button which directs the user to the primary beacon use page", () => {
+  it("should have a back button which directs the user to the more details page", () => {
     render(<AboutBeaconOwner form={emptyAboutBeaconOwnerForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -65,7 +65,7 @@ describe("AboutTheVessel", () => {
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",
-      "/register-a-beacon/primary-beacon-use"
+      "/register-a-beacon/activity"
     );
   });
 

--- a/test/pages/register-a-beacon/activity.test.tsx
+++ b/test/pages/register-a-beacon/activity.test.tsx
@@ -13,7 +13,7 @@ jest.mock("../../../src/lib/handlePageRequest", () => ({
 }));
 
 describe("Activity", () => {
-  const primaryBeaconUseForm: FormJSON = {
+  const activityForm: FormJSON = {
     hasErrors: false,
     errorSummary: [],
     fields: {
@@ -29,7 +29,7 @@ describe("Activity", () => {
   };
 
   it("should have a back button which directs the user to the beacon information page", () => {
-    render(<Activity form={primaryBeaconUseForm} />);
+    render(<Activity form={activityForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",

--- a/test/pages/register-a-beacon/activity.test.tsx
+++ b/test/pages/register-a-beacon/activity.test.tsx
@@ -3,16 +3,16 @@ import { GetServerSidePropsContext } from "next";
 import React from "react";
 import { FormJSON } from "../../../src/lib/form/formManager";
 import { handlePageRequest } from "../../../src/lib/handlePageRequest";
-import PrimaryBeaconUse, {
+import Activity, {
   getServerSideProps,
-} from "../../../src/pages/register-a-beacon/primary-beacon-use";
+} from "../../../src/pages/register-a-beacon/activity";
 
 jest.mock("../../../src/lib/handlePageRequest", () => ({
   __esModule: true,
   handlePageRequest: jest.fn().mockImplementation(() => jest.fn()),
 }));
 
-describe("PrimaryBeaconUse", () => {
+describe("Activity", () => {
   const primaryBeaconUseForm: FormJSON = {
     hasErrors: false,
     errorSummary: [],
@@ -29,7 +29,7 @@ describe("PrimaryBeaconUse", () => {
   };
 
   it("should have a back button which directs the user to the beacon information page", () => {
-    render(<PrimaryBeaconUse form={primaryBeaconUseForm} />);
+    render(<Activity form={primaryBeaconUseForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
       "href",

--- a/test/pages/register-a-beacon/emergency-contact.test.tsx
+++ b/test/pages/register-a-beacon/emergency-contact.test.tsx
@@ -56,7 +56,7 @@ describe("EmergencyContact", () => {
     errorSummary: [],
   };
 
-  it("should have a back button which directs the user to the primary beacon use page", () => {
+  it("should have a back button which directs the user to the beacon owner page", () => {
     render(<EmergencyContact form={emptyEmergencyContactForm} />);
 
     expect(screen.getByText("Back", { exact: true })).toHaveAttribute(

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -37,17 +37,6 @@ describe("PrimaryBeaconUse", () => {
     );
   });
 
-  it("should POST its form submission to itself for redirection via getServerSideProps()", () => {
-    const { container } = render(
-      <PrimaryBeaconUse form={primaryBeaconUseForm} />
-    );
-    const ownPath = "/register-a-beacon/primary-beacon-use";
-
-    const form = container.querySelectorAll("form")[1];
-
-    expect(form).toHaveAttribute("action", ownPath);
-  });
-
   it("should redirect to about-the-vessel page on valid form submission", async () => {
     const context = {};
     await getServerSideProps(context as GetServerSidePropsContext);


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The current `primary-beacon-use` [page](http://staging-beacons-7293500.eu-west-2.elb.amazonaws.com/register-a-beacon/primary-beacon-use) will become the `L3` page with the path `/register-a-beacon/activity`.

This page will have essentially 4 different views depending on what was submitted on the previous two pages `L1` and `L2`:
- Martime & Pleasure (what's currently on this page)
- Maritime & Commercial
- Aviation & Pleasure
- Aviation & Commercial
- Land/Other

This is the first :smol: 🍰 

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Make use of ✨ `BeaconsForm` ✨ component
- Move the current `RadiotList` into component called `MaritimePleasureOptions`
   - A similar component will be created for each of the options above and rendered depending on the previous `L1` and `L2` choices in the cache
- Rename the page - `primary-beacon-use` ➡️ `activity`
   - And change references to it accordingly
 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I was a little unsure about how to do this at the beginning.
But I used @stuart-madetech's suggestion 🙏  of having separate components that will get rendered depending on the previous options selected.
That seems like the best way to handle this to me - but I thought I'd get this idea in front of everyone in case anyone has thoughts on it.

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/jfX3FTeZ/309-primary-beacon-use-selection-page-l3-sub-category-selection-page

