### PR TITLE
Fix FormGroup

### DIFF
--- a/src/components/BeaconsForm.tsx
+++ b/src/components/BeaconsForm.tsx
@@ -14,8 +14,8 @@ interface BeaconsFormProps {
   pageHeading: string;
   showCookieBanner: boolean;
   formErrors?: FormError[];
-  errorMessages?: string[];
   insetText?: ReactNode;
+  errorMessagesIfSingleField?: string[];
 }
 
 export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
@@ -24,8 +24,8 @@ export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
   pageHeading,
   showCookieBanner,
   formErrors = [],
-  errorMessages = [],
   insetText = null,
+  errorMessagesIfSingleField = [],
 }: BeaconsFormProps): JSX.Element => {
   let insetComponent;
   if (insetText) {
@@ -43,7 +43,9 @@ export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
           <>
             <FormErrorSummary formErrors={formErrors} />
             <Form>
-              <FormGroup errorMessages={errorMessages}>
+              <FormGroup
+                errorMessagesIfSingleField={errorMessagesIfSingleField}
+              >
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
                 </FormFieldset>

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -17,6 +17,7 @@ interface FormGroupProps {
   children: ReactNode;
   className?: string;
   errorMessages?: string[];
+  errorMessagesIfSingleField?: string[];
 }
 
 interface FormLabelProps {
@@ -55,8 +56,10 @@ export const FormGroup: FunctionComponent<FormGroupProps> = ({
   children,
   className = "",
   errorMessages = [],
+  errorMessagesIfSingleField = [],
 }: FormGroupProps): JSX.Element => {
-  const showErrors = errorMessages.length > 0;
+  const showErrors =
+    errorMessages.length > 0 || errorMessagesIfSingleField.length > 0;
   const errorClassName: string = showErrors ? "govuk-form-group--error" : "";
 
   let errorsComponent: ReactNode;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -62,7 +62,7 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
             <FormErrorSummary formErrors={form.errorSummary} />
             <Form action="/register-a-beacon/primary-beacon-use">
               <FormGroup
-                errorMessages={
+                errorMessagesIfSingleField={
                   form.fields.maritimePleasureVesselUse.errorMessages
                 }
               >
@@ -72,75 +72,83 @@ const PrimaryBeaconUse: FunctionComponent<FormPageProps> = ({
                     this beacon on?
                   </FormLegendPageHeading>
                 </FormFieldset>
-                <RadioList conditional={true}>
-                  <RadioListItem
-                    id="motor-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.MOTOR}
-                    label="Motor vessel"
-                    hintText="E.g. Speedboat, RIB"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.MOTOR
-                    }
-                  />
-                  <RadioListItem
-                    id="sailing-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.SAILING}
-                    label="Sailing vessel"
-                    hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.SAILING
-                    }
-                  />
-                  <RadioListItem
-                    id="rowing-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.ROWING}
-                    label="Rowing vessel"
-                    hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.ROWING
-                    }
-                  />
-                  <RadioListItem
-                    id="maritimePleasureVesselUse"
-                    value={MaritimePleasureVessel.SMALL_UNPOWERED}
-                    label="Small unpowered vessel"
-                    hintText="E.g. Canoe, Kayak"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.SMALL_UNPOWERED
-                    }
-                  />
-                  <RadioListItem
-                    id="other-pleasure-vessel"
-                    name={maritimePleasureVesselName}
-                    value={MaritimePleasureVessel.OTHER}
-                    label="Other pleasure vessel"
-                    hintText="E.g. Surfboard, Kitesurfing"
-                    defaultChecked={
-                      form.fields.maritimePleasureVesselUse.value ===
-                      MaritimePleasureVessel.OTHER
-                    }
-                    conditional={true}
-                  >
-                    <FormGroup
-                      errorMessages={
-                        form.fields.otherPleasureVesselText.errorMessages
+                <FormGroup
+                  errorMessages={
+                    form.fields.maritimePleasureVesselUse.errorMessages
+                  }
+                >
+                  <RadioList conditional={true}>
+                    <RadioListItem
+                      id="motor-vessel"
+                      name={maritimePleasureVesselName}
+                      value={MaritimePleasureVessel.MOTOR}
+                      label="Motor vessel"
+                      hintText="E.g. Speedboat, RIB"
+                      defaultChecked={
+                        form.fields.maritimePleasureVesselUse.value ===
+                        MaritimePleasureVessel.MOTOR
                       }
+                    />
+                    <RadioListItem
+                      id="sailing-vessel"
+                      name={maritimePleasureVesselName}
+                      value={MaritimePleasureVessel.SAILING}
+                      label="Sailing vessel"
+                      hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+                      defaultChecked={
+                        form.fields.maritimePleasureVesselUse.value ===
+                        MaritimePleasureVessel.SAILING
+                      }
+                    />
+                    <RadioListItem
+                      id="rowing-vessel"
+                      name={maritimePleasureVesselName}
+                      value={MaritimePleasureVessel.ROWING}
+                      label="Rowing vessel"
+                      hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+                      defaultChecked={
+                        form.fields.maritimePleasureVesselUse.value ===
+                        MaritimePleasureVessel.ROWING
+                      }
+                    />
+                    <RadioListItem
+                      id="maritimePleasureVesselUse"
+                      value={MaritimePleasureVessel.SMALL_UNPOWERED}
+                      label="Small unpowered vessel"
+                      hintText="E.g. Canoe, Kayak"
+                      defaultChecked={
+                        form.fields.maritimePleasureVesselUse.value ===
+                        MaritimePleasureVessel.SMALL_UNPOWERED
+                      }
+                    />
+                    <RadioListItem
+                      id="other-pleasure-vessel"
+                      name={maritimePleasureVesselName}
+                      value={MaritimePleasureVessel.OTHER}
+                      label="Other pleasure vessel"
+                      hintText="E.g. Surfboard, Kitesurfing"
+                      defaultChecked={
+                        form.fields.maritimePleasureVesselUse.value ===
+                        MaritimePleasureVessel.OTHER
+                      }
+                      conditional={true}
                     >
-                      <Input
-                        id="otherPleasureVesselText"
-                        label="What sort of vessel is it?"
-                        defaultValue={form.fields.otherPleasureVesselText.value}
-                      />
-                    </FormGroup>
-                  </RadioListItem>
-                </RadioList>
+                      <FormGroup
+                        errorMessages={
+                          form.fields.otherPleasureVesselText.errorMessages
+                        }
+                      >
+                        <Input
+                          id="otherPleasureVesselText"
+                          label="What sort of vessel is it?"
+                          defaultValue={
+                            form.fields.otherPleasureVesselText.value
+                          }
+                        />
+                      </FormGroup>
+                    </RadioListItem>
+                  </RadioList>
+                </FormGroup>
               </FormGroup>
 
               <Button buttonText="Continue" />


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
This is not a big issue - and @matthew-a-carr and I only spotted this because of the new BeaconsForm.

But basically on Pages with just one field, the Error Message isn't being displayed correctly.

This change attempts to fix this - and it does, but it's not very pretty.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add `errorMessagesIfSingleField` prop to `FormGroup` so it can be used to apply the _red left bar_ to Page Headings that are also the only question/field on a page
- Add another `FormGroup` to `primary-beacon-use` page to correct error message placement 

![image](https://user-images.githubusercontent.com/32230328/112362393-4bed6c00-8ccc-11eb-8060-89e3e937430f.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I was very unsure about what to call the new property. 😬 

And this doesn't feel super nice - but thought I'd open a PR for a little fix anyway - but I also don't mind closing this and opening an issue instead if we want to attempt a nicer fix later

