### PR TITLE
Add more details page

### DIFF
--- a/cypress/integration/moreDetails.spec.tsx
+++ b/cypress/integration/moreDetails.spec.tsx
@@ -14,7 +14,7 @@ import {
 describe("As a beacon owner and maritime pleasure vessel user", () => {
   const thisPageUrl = "/register-a-beacon/more-details";
   const nextPageUrl = "/register-a-beacon/about-beacon-owner";
-  const previousPageUrl = "/register-a-beacon/communications";
+  const previousPageUrl = "/register-a-beacon/vessel-communications";
 
   const moreDetailsTextareaSelector = "#moreDetails";
 

--- a/cypress/integration/moreDetails.spec.tsx
+++ b/cypress/integration/moreDetails.spec.tsx
@@ -14,7 +14,7 @@ import {
 describe("As a beacon owner and maritime pleasure vessel user", () => {
   const thisPageUrl = "/register-a-beacon/more-details";
   const nextPageUrl = "/register-a-beacon/about-beacon-owner";
-  const previousPageUrl = "/register-a-beacon/vessel-communications";
+  const previousPageUrl = "/register-a-beacon/communications";
 
   const moreDetailsTextareaSelector = "#moreDetails";
 

--- a/src/pages/register-a-beacon/more-details.tsx
+++ b/src/pages/register-a-beacon/more-details.tsx
@@ -11,6 +11,7 @@ import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { TextareaCharacterCount } from "../../components/Textarea";
+import { GovUKBody } from "../../components/Typography";
 import { FieldManager } from "../../lib/form/fieldManager";
 import { FormManager } from "../../lib/form/formManager";
 import { Validators } from "../../lib/form/validators";
@@ -58,25 +59,23 @@ const MoreDetails: FunctionComponent<FormPageProps> = ({
               <Form>
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
-                  <div className="govuk-details">
-                    <p className="">
-                      Please provide a description of any vessel, aircraft,
-                      vehicle or anything else associated with this beacon.
-                    </p>
-                    <p className="">
-                      This might include defining features such as the length,
-                      colour etc) and any tracking details (e.g. RYA SafeTrx or
-                      Web) if you have them.
-                    </p>
-                    <p className="govuk-!-font-weight-bold">
-                      Please do not provide medical details as we cannot store
-                      these.
-                    </p>
-                    <p className="">
-                      This information is very helpful to Search and Rescue when
-                      trying to locate you
-                    </p>
-                  </div>
+                  <GovUKBody>
+                    Please provide a description of any vessel, aircraft,
+                    vehicle or anything else associated with this beacon.
+                  </GovUKBody>
+                  <GovUKBody>
+                    This might include defining features such as the length,
+                    colour etc) and any tracking details (e.g. RYA SafeTrx or
+                    Web) if you have them.
+                  </GovUKBody>
+                  <GovUKBody className="govuk-!-font-weight-bold">
+                    Please do not provide medical details as we cannot store
+                    these.
+                  </GovUKBody>
+                  <GovUKBody>
+                    This information is very helpful to Search and Rescue when
+                    trying to locate you
+                  </GovUKBody>
                   <MoreDetailsTextArea
                     id="moreDetails"
                     value={form.fields.moreDetails.value}


### PR DESCRIPTION
## Context

- Add more details page for registering a beacon use

## Changes in this pull request

- Adds more details page and routes to the about the beacon owner page afterwards

## Link to Trello card

- https://trello.com/c/T6GHFq9H/377-update-the-more-details-page-to-be-generic

## Things to check

- [ ] Environment variables have been updated
