### PR TITLE
Add basic auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8528,6 +8528,11 @@
         "watchpack": "2.1.1"
       }
     },
+    "nextjs-basic-auth": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nextjs-basic-auth/-/nextjs-basic-auth-0.1.2.tgz",
+      "integrity": "sha512-BaXvqeT+uUrRh6l0RCOlDJhB1wUsppboi4eGBBLKAh/qDbipSQ32KY7M2Y1vLvqTYjPj1zYCq3E3Q7+S0flfXw=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "google-libphonenumber": "^3.2.19",
     "govuk-frontend": "^3.11.0",
     "next": "10.1.3",
+    "nextjs-basic-auth": "^0.1.2",
     "notifications-node-client": "^5.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/src/gateways/basicAuthGateway.ts
+++ b/src/gateways/basicAuthGateway.ts
@@ -1,0 +1,22 @@
+import { IncomingMessage, ServerResponse } from "http";
+import initializeBasicAuth from "nextjs-basic-auth";
+
+export class BasicAuthGateway {
+  authenticator;
+  constructor() {
+    if (process.env.BASIC_AUTH) {
+      const credentials = JSON.parse(process.env.BASIC_AUTH);
+
+      this.authenticator = initializeBasicAuth({
+        users: credentials,
+      });
+    }
+  }
+
+  async authenticate(
+    request: IncomingMessage,
+    response: ServerResponse
+  ): Promise<void> {
+    if (this.authenticator) return await this.authenticator(request, response);
+  }
+}

--- a/src/lib/handlePageRequest.ts
+++ b/src/lib/handlePageRequest.ts
@@ -3,6 +3,8 @@ import {
   GetServerSidePropsContext,
   GetServerSidePropsResult,
 } from "next";
+import { BasicAuthGateway } from "../gateways/basicAuthGateway";
+import { AuthenticateUser } from "../useCases/authenticateUser";
 import { FormJSON, FormManager } from "./form/formManager";
 import { FormSubmission } from "./formCache";
 import {
@@ -34,6 +36,10 @@ export const handlePageRequest = (
     destinationIfValid
 ): GetServerSideProps =>
   withCookieRedirect(async (context: GetServerSidePropsContext) => {
+    const authGateway = new BasicAuthGateway();
+    const authUseCase = new AuthenticateUser(authGateway);
+    await authUseCase.execute(context);
+
     const beaconsContext: BeaconsContext = await decorateGetServerSidePropsContext(
       context
     );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { AppProps } from "next/app";
+import { AppProps } from "next/app";
 import Head from "next/head";
 import React, { FunctionComponent, useEffect } from "react";
 import "../styles/globals.scss";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,8 +15,10 @@ import {
   SectionHeading,
 } from "../components/Typography";
 import { WarningText } from "../components/WarningText";
+import { BasicAuthGateway } from "../gateways/basicAuthGateway";
 import { setFormSubmissionCookie } from "../lib/middleware";
 import { acceptRejectCookieId } from "../lib/types";
+import { AuthenticateUser } from "../useCases/authenticateUser";
 
 interface ServiceStartPageProps {
   showCookieBanner: boolean;
@@ -196,6 +198,10 @@ const DataProtection: FunctionComponent = (): JSX.Element => (
 export const getServerSideProps: GetServerSideProps = async (
   context: GetServerSidePropsContext
 ) => {
+  const authGateway = new BasicAuthGateway();
+  const authUseCase = new AuthenticateUser(authGateway);
+  await authUseCase.execute(context);
+
   setFormSubmissionCookie(context);
   const showCookieBanner = !context.req.cookies[acceptRejectCookieId];
 

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -86,7 +86,7 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
         govNotifyGateway
       );
       if (sendGovNotifyEmailUseCase.execute(registration)) {
-        pageSubHeading = "We have sent you a confirmation email - ";
+        pageSubHeading = "We have sent you a confirmation email.";
       } else {
         pageSubHeading = "We could not send you a confirmation email.";
       }

--- a/src/useCases/authenticateUser.ts
+++ b/src/useCases/authenticateUser.ts
@@ -1,0 +1,12 @@
+import { BasicAuthGateway } from "../gateways/basicAuthGateway";
+
+export class AuthenticateUser {
+  gateway;
+  constructor(BasicAuthGateway: BasicAuthGateway) {
+    this.gateway = BasicAuthGateway;
+  }
+
+  async execute(context): Promise<void> {
+    await this.gateway.authenticate(context.req, context.res);
+  }
+}

--- a/test/lib/handlePageRequest.test.ts
+++ b/test/lib/handlePageRequest.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../src/lib/utils", () => ({
     .fn()
     .mockImplementation((dest) => `${dest}?useIndex=1`),
 }));
+jest.mock("../../src/gateways/basicAuthGateway");
 
 describe("handlePageRequest()", () => {
   let getFormGroup;

--- a/test/pages/index.test.tsx
+++ b/test/pages/index.test.tsx
@@ -9,6 +9,7 @@ jest.mock("../../src/lib/middleware", () => {
     setFormSubmissionCookie: jest.fn(),
   };
 });
+jest.mock("../../src/gateways/basicAuthGateway");
 
 describe("ServiceStartPage", () => {
   it("should have a start now button which directs the user to check your beacon details page", () => {


### PR DESCRIPTION
## Context

Implement basic auth

## Changes in this pull request

Adding basic auth to most pages, optionally for local environments.

## Guidance to review

Consider cleaner way of getting this into every page? And of getting this tested through cypress, not just mocks in jest.

If the env var BASIC_AUTH is not set, basic auth is disabled. This applies to all stages - so adding that is required.

BASIC_AUTH follows the following JSON format: `[{"user": "", "password": ""}]`

## Link to Trello card

https://trello.com/c/VM6cwzoi/418-lock-web-app-down-behind-basic-authentication

## Things to check

- [-] Environment variables have been updated
