### PR TITLE
🐛 Fixes first slice 🍰 

### DIFF
--- a/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
@@ -1,5 +1,6 @@
 import { Environment, Purpose } from "../../../../src/lib/registration/types";
 import { PageURLs } from "../../../../src/lib/urls";
+import { makeEnumValueUserFriendly } from "../../../../src/lib/utils";
 import {
   testAviationCommercialUseData,
   testAviationPleasureUseData,
@@ -144,12 +145,12 @@ export const iCanSeeMyAviationUse = (purpose: Purpose): void => {
   switch (purpose) {
     case Purpose.COMMERCIAL:
       Object.values(testAviationCommercialUseData.type).forEach((value) => {
-        cy.get("main").contains(value);
+        cy.get("main").contains(makeEnumValueUserFriendly(value));
       });
       break;
     case Purpose.PLEASURE:
       Object.values(testAviationPleasureUseData.type).forEach((value) => {
-        cy.get("main").contains(value);
+        cy.get("main").contains(makeEnumValueUserFriendly(value));
       });
       break;
   }

--- a/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
@@ -1,5 +1,6 @@
 import { Environment, Purpose } from "../../../../src/lib/registration/types";
 import { PageURLs } from "../../../../src/lib/urls";
+import { makeEnumValueUserFriendly } from "../../../../src/lib/utils";
 import {
   testMaritimeCommercialUseData,
   testMaritimePleasureUseData,
@@ -66,12 +67,12 @@ export const iCanSeeMyMaritimeUse = (purpose: Purpose): void => {
   switch (purpose) {
     case Purpose.COMMERCIAL:
       Object.values(testMaritimeCommercialUseData.type).forEach((value) => {
-        cy.get("main").contains(value);
+        cy.get("main").contains(makeEnumValueUserFriendly(value));
       });
       break;
     case Purpose.PLEASURE:
       Object.values(testMaritimePleasureUseData.type).forEach((value) => {
-        cy.get("main").contains(value);
+        cy.get("main").contains(makeEnumValueUserFriendly(value));
       });
       break;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,7 +20,7 @@ export function toUpperCase(value: string): string {
 }
 
 /**
- * Convenience function for making an enum value, that could be nullish, user friendly i.e. underscores removed and title-cased.
+ * Convenience function for making an enum value, that could be nullish, user friendly i.e. underscores removed and sentence-cased.
  *
  * @param value {string}   The string value; could be null
  * @returns     {string}   The string value made user friendly

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,20 @@ export function toUpperCase(value: string): string {
 }
 
 /**
+ * Convenience function for making an enum value, that could be nullish, user friendly i.e. underscores removed and title-cased.
+ *
+ * @param value {string}   The string value; could be null
+ * @returns     {string}   The string value made user friendly
+ */
+export function makeEnumValueUserFriendly(value: string): string {
+  if (value) {
+    value = value.replace(/_/g, " ");
+    return value[0] + value.slice(1).toLowerCase();
+  }
+  return value;
+}
+
+/**
  * Given the provided string is a number, pads the value with zeros until it reaches the target length.
  *
  * @param value        {string}   The number as a string

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -207,14 +207,14 @@ const Dongle: FunctionComponent<FormInputProps> = ({
           id="dongle-no"
           name="dongle"
           value="false"
-          label="no"
+          label="No"
           defaultChecked={value === "false"}
         />
         <RadioListItem
           id="dongle-yes"
           name="dongle"
           value="true"
-          label="yes"
+          label="Yes"
           defaultChecked={value === "true"}
         />
       </RadioList>

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -109,7 +109,7 @@ export const ActivityOptions: FunctionComponent<ActivityOptionsProps> = ({
     );
 
   throw new Error(
-    "Environment or purpose not found.  User needs to enter evironment and purpose on previous pages."
+    "Environment or purpose not found.  User needs to enter environment and purpose on previous pages."
   );
 };
 

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -19,6 +19,7 @@ import {
   Environment,
   IRegistration,
 } from "../../lib/registration/types";
+import { makeEnumValueUserFriendly } from "../../lib/utils";
 
 interface CheckYourAnswersProps {
   registration: IRegistration;
@@ -210,9 +211,15 @@ const BeaconUseSection: FunctionComponent<CheckYourAnswersBeaconUseSectionProps>
 
       <SummaryList>
         <SummaryListItem labelText="Beacon use" href={href} actionText="Change">
-          <CheckYourAnswersDataRowItem value={use.environment} />
-          <CheckYourAnswersDataRowItem value={use.purpose} />
-          <CheckYourAnswersDataRowItem value={use.activity} />
+          <CheckYourAnswersDataRowItem
+            value={makeEnumValueUserFriendly(use.environment)}
+          />
+          <CheckYourAnswersDataRowItem
+            value={makeEnumValueUserFriendly(use.purpose)}
+          />
+          <CheckYourAnswersDataRowItem
+            value={makeEnumValueUserFriendly(use.activity)}
+          />
         </SummaryListItem>
       </SummaryList>
       {aboutTheSection}

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -161,7 +161,7 @@ const BeaconUseSection: FunctionComponent<CheckYourAnswersBeaconUseSectionProps>
   index,
   use,
 }: CheckYourAnswersBeaconUseSectionProps): JSX.Element => {
-  const href = `/register-a-beacon/envionment?useIndex=${index}"`;
+  const href = `/register-a-beacon/beacon-use?useIndex=${index}`;
   let aboutTheSection = <></>;
   let commsSection = <></>;
   switch (use.environment) {

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -61,11 +61,11 @@ describe("makeEnumValueUserFriendly()", () => {
     expect(makeEnumValueUserFriendly(null)).toBe(null);
   });
 
-  it("should return the value title-cased", () => {
+  it("should return the value sentence-cased", () => {
     expect(makeEnumValueUserFriendly("UPPERCASE")).toBe("Uppercase");
   });
 
-  it("should replace underscores with spaces and return the value title-cased", () => {
+  it("should replace underscores with spaces and return the value sentence-cased", () => {
     expect(makeEnumValueUserFriendly("UPPER_CASE")).toBe("Upper case");
   });
 });

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   formatUrlQueryParams,
+  makeEnumValueUserFriendly,
   padNumberWithLeadingZeros,
   toArray,
   toUpperCase,
@@ -52,6 +53,20 @@ describe("toUpperCase()", () => {
 
   it("should handle only numbers", () => {
     expect(toUpperCase("123")).toBe("123");
+  });
+});
+
+describe("makeEnumValueUserFriendly()", () => {
+  it("should return the value unchanged if the value is null", () => {
+    expect(makeEnumValueUserFriendly(null)).toBe(null);
+  });
+
+  it("should return the value title-cased", () => {
+    expect(makeEnumValueUserFriendly("UPPERCASE")).toBe("Uppercase");
+  });
+
+  it("should replace underscores with spaces and return the value title-cased", () => {
+    expect(makeEnumValueUserFriendly("UPPER_CASE")).toBe("Upper case");
   });
 });
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
There were some bugs noticed during/after the last show and tell.
These are the first few fixes!

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Fix `Change` link for the `Use` section on `/check-your-answers` page

- ✨ _**~Title-case~ Sentence-case**_ ✨ for `/about-the-aircraft`
<img width=350 src="https://user-images.githubusercontent.com/32230328/114718717-2fbe7700-9d2e-11eb-8c76-e420ba385237.png"></img> ➡️ <img width=350 src="https://user-images.githubusercontent.com/32230328/114710376-8c696400-9d25-11eb-8e7f-401ce3a49848.png"></img>

- Make `environment`, `purpose` and `activity` User-friendly 💕 
<img width=350 src="https://user-images.githubusercontent.com/32230328/114720390-e53dfa00-9d2f-11eb-8fb6-8e5b7a4666bf.png"></img> ➡️ <img width=350 src="https://user-images.githubusercontent.com/32230328/114719738-4a452000-9d2f-11eb-8eb3-a8a441f966fc.png"></img>


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
In the [ticket](https://trello.com/c/5DfSI6PB/421-bugs-in-show-tell-7) description, it says to _"create a lookup from enum value to display text"_ to make the `environment`, `purpose` and `activity` User-friendly
   - Instead, I made a function `makeEnumValueUserFriendly` (I'm never confident with naming things, please let me know if you have a better one in mind 😅 ) to change the enum value to be User-friendly
   - Did this so that if we were to add/change an `environment`, `purpose` or `activity`, we don't need to worry about making the changes in lots of places?
   
## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/5DfSI6PB/421-bugs-in-show-tell-7
