### PR TITLE
Bugfix/beaconsform text styling

### DIFF
--- a/src/components/BeaconsForm.tsx
+++ b/src/components/BeaconsForm.tsx
@@ -7,6 +7,7 @@ import { Form, FormFieldset, FormGroup, FormLegendPageHeading } from "./Form";
 import { Grid } from "./Grid";
 import { Layout } from "./Layout";
 import { IfYouNeedHelp } from "./Mca";
+import { GovUKBody } from "./Typography";
 
 interface BeaconsFormProps {
   children: ReactNode;
@@ -15,7 +16,7 @@ interface BeaconsFormProps {
   showCookieBanner: boolean;
   formErrors?: FormError[];
   errorMessages?: string[];
-  pageText?: ReactNode;
+  pageText?: string | ReactNode;
   includeUseIndex?: boolean;
 }
 
@@ -49,7 +50,11 @@ export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
               <FormGroup errorMessages={errorMessages}>
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
-                  {pageText}
+                  {typeof pageText === "string" ? (
+                    <GovUKBody>{pageText}</GovUKBody>
+                  ) : (
+                    pageText
+                  )}
                 </FormFieldset>
                 {children}
                 <HiddenFormMetadata />

--- a/src/components/BeaconsForm.tsx
+++ b/src/components/BeaconsForm.tsx
@@ -36,6 +36,9 @@ export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
     <BackButton href={previousPageUrl} />
   );
 
+  const pageTextComponent: ReactNode =
+    typeof pageText === "string" ? <GovUKBody>{pageText}</GovUKBody> : pageText;
+
   return (
     <Layout
       navigation={backButton}
@@ -50,11 +53,7 @@ export const BeaconsForm: FunctionComponent<BeaconsFormProps> = ({
               <FormGroup errorMessages={errorMessages}>
                 <FormFieldset>
                   <FormLegendPageHeading>{pageHeading}</FormLegendPageHeading>
-                  {typeof pageText === "string" ? (
-                    <GovUKBody>{pageText}</GovUKBody>
-                  ) : (
-                    pageText
-                  )}
+                  {pageTextComponent}
                 </FormFieldset>
                 {children}
                 <HiddenFormMetadata />

--- a/test/components/BeaconsForm.test.tsx
+++ b/test/components/BeaconsForm.test.tsx
@@ -14,7 +14,7 @@ describe("BeaconsForm Component", () => {
   let pageHeading;
   let showCookieBanner;
   let errorMessages;
-  let insetText;
+  let pageText;
 
   beforeEach(() => {
     children = <h1>Beacons for life</h1>;
@@ -22,7 +22,7 @@ describe("BeaconsForm Component", () => {
     pageHeading = "A day in the beacon life";
     showCookieBanner = true;
     errorMessages = ["This is an error"];
-    insetText = "Once upon a time a person with a beacon walked the seas";
+    pageText = "Once upon a time a person with a beacon walked the seas";
   });
 
   it("should render the beacons form component", () => {
@@ -81,13 +81,13 @@ describe("BeaconsForm Component", () => {
         previousPageUrl={previousPageUrl}
         pageHeading={pageHeading}
         showCookieBanner={showCookieBanner}
-        insetText={insetText}
+        insetText={pageText}
       >
         {children}
       </BeaconsForm>
     );
 
-    expect(screen.getByText(insetText)).toBeDefined();
+    expect(screen.getByText(pageText)).toBeDefined();
   });
 
   it("should not render the inset text if it is not provided", () => {
@@ -101,7 +101,24 @@ describe("BeaconsForm Component", () => {
       </BeaconsForm>
     );
 
-    expect(screen.queryByText(insetText)).toBeNull();
+    expect(screen.queryByText(pageText)).toBeNull();
+  });
+
+  it("should apply govuk-body class to pageText if not already wrapped in a React component", () => {
+    render(
+      <BeaconsForm
+        previousPageUrl={previousPageUrl}
+        pageHeading={pageHeading}
+        showCookieBanner={showCookieBanner}
+        pageText={pageText}
+      >
+        {children}
+      </BeaconsForm>
+    );
+
+    expect(screen.queryByText(pageText).classList.contains("govuk-body")).toBe(
+      true
+    );
   });
 
   it("should render the error messages if provided", () => {

--- a/test/components/BeaconsForm.test.tsx
+++ b/test/components/BeaconsForm.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { BeaconsForm } from "../../src/components/BeaconsForm";
+import { InsetText } from "../../src/components/InsetText";
 
 jest.mock("next/router", () => ({
   useRouter: jest.fn().mockImplementation(() => ({
@@ -118,6 +119,23 @@ describe("BeaconsForm Component", () => {
 
     expect(screen.queryByText(pageText).classList.contains("govuk-body")).toBe(
       true
+    );
+  });
+
+  it("should not apply govuk-body class to pageText if already wrapped in a React component", () => {
+    render(
+      <BeaconsForm
+        previousPageUrl={previousPageUrl}
+        pageHeading={pageHeading}
+        showCookieBanner={showCookieBanner}
+        pageText={<InsetText>{pageText}</InsetText>}
+      >
+        {children}
+      </BeaconsForm>
+    );
+
+    expect(screen.queryByText(pageText).classList.contains("govuk-body")).toBe(
+      false
     );
   });
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

To fix bug whereby `<BeaconsForm>` displayed string values of prop `pageText` without styling:
![image](https://user-images.githubusercontent.com/54271433/115009018-b9438580-9ea3-11eb-8289-d45c6236318a.png)

===>

![image](https://user-images.githubusercontent.com/54271433/115009745-8057e080-9ea4-11eb-9b68-700bd051e342.png)


## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Set type of `pageText` prop to be either `string` or `ReactNode`
- If `typeof pageText === "string"`, wrap it in `<GovUKBody>`
- Else, it is already wrapped in a React element, and so display it as-is.
- 2 x unit tests for above.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

I considered the alternative of requiring each page to specify the React component in which `pageText` should be wrapped.  

I decided against this, as the most common pattern is to style text between the header and the form in `GovUKBody`, so it would require a lot of boilerplate on each page.

The approach proposed in this PR allows the pages to simply inject the copy text as a string, reducing decisions that need to be made on a page-by-page basis, but also allowing exceptions.

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
