### PR TITLE
Add RSS number field to about-vessel-page and BeaconUse

### DIFF
--- a/cypress/integration/common/happy-path-test-data.spec.ts
+++ b/cypress/integration/common/happy-path-test-data.spec.ts
@@ -97,6 +97,7 @@ export const testMaritimeUseData = {
     typicalAO: "Suez Canal AO",
     imoNumber: "9811000",
     ssrNumber: "1664",
+    rssNumber: "A12345",
     officialNumber: "1313",
     rigPlatformLocation: "Suez Canal",
   },

--- a/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
@@ -249,6 +249,7 @@ export const givenIHaveEnteredInformationAboutMyVessel = (): void => {
   givenIHaveTyped(vessel.typicalAO, "#areaOfOperation");
   givenIHaveTyped(vessel.imoNumber, "#imoNumber");
   givenIHaveTyped(vessel.ssrNumber, "#ssrNumber");
+  givenIHaveTyped(vessel.rssNumber, "#rssNumber");
   givenIHaveTyped(vessel.officialNumber, "#officialNumber");
   givenIHaveTyped(vessel.rigPlatformLocation, "#rigPlatformLocation");
 };

--- a/src/lib/registration/registration.ts
+++ b/src/lib/registration/registration.ts
@@ -193,6 +193,7 @@ export class Registration {
       beaconLocation: use.beaconLocation,
       imoNumber: use.imoNumber,
       ssrNumber: use.ssrNumber,
+      rssNumber: use.rssNumber,
       officialNumber: use.officialNumber,
       rigPlatformLocation: use.rigPlatformLocation,
       mainUse,

--- a/src/lib/registration/registrationInitialisation.ts
+++ b/src/lib/registration/registrationInitialisation.ts
@@ -82,6 +82,7 @@ export const initBeaconUse = (): BeaconUse => {
     beaconLocation: "",
     imoNumber: "",
     ssrNumber: "",
+    rssNumber: "",
     officialNumber: "",
     rigPlatformLocation: "",
 

--- a/src/lib/registration/types.ts
+++ b/src/lib/registration/types.ts
@@ -65,6 +65,7 @@ export interface BeaconUse {
   beaconLocation: string;
   imoNumber: string;
   ssrNumber: string;
+  rssNumber: string;
   officialNumber: string;
   rigPlatformLocation: string;
 

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -22,6 +22,7 @@ const definePageForm = ({
   areaOfOperation,
   imoNumber,
   ssrNumber,
+  rssNumber,
   officialNumber,
   rigPlatformLocation,
 }: FormSubmission): FormManager => {
@@ -51,6 +52,7 @@ const definePageForm = ({
     ]),
     imoNumber: new FieldManager(imoNumber),
     ssrNumber: new FieldManager(ssrNumber),
+    rssNumber: new FieldManager(rssNumber),
     officialNumber: new FieldManager(officialNumber),
     rigPlatformLocation: new FieldManager(rigPlatformLocation),
   });
@@ -95,6 +97,7 @@ const AboutTheVessel: FunctionComponent<FormPageProps> = ({
       />
       <ImoNumberInput value={form.fields.imoNumber.value} />
       <SsrNumberInput value={form.fields.ssrNumber.value} />
+      <RssNumberInput value={form.fields.rssNumber.value} />
       <OfficialNumberInput value={form.fields.officialNumber.value} />
       <SectionHeading>Windfarm, rig or platform information</SectionHeading>
       <RigPlatformLocationInput value={form.fields.rigPlatformLocation.value} />
@@ -195,6 +198,19 @@ const SsrNumberInput: FunctionComponent<FormInputProps> = ({
       id="ssrNumber"
       label="If you have one, enter the UK Small Ships Register (SSR)  number (optional)"
       hintText="E.g. SSR 123456. The Small Ships Register (SSR) provides a simple form of non-title registration for eligible UK residents who own pleasure vessels that are  less than 24 metres in overall length."
+      defaultValue={value}
+    />
+  </FormGroup>
+);
+
+const RssNumberInput: FunctionComponent<FormInputProps> = ({
+  value = "",
+}: FormInputProps): JSX.Element => (
+  <FormGroup>
+    <Input
+      id="rssNumber"
+      label="If you own or use a fishing vessel and it’s registered with the Registry of Shipping and Seamen (RSS), please provide your RSS number (optional)"
+      hintText="RSS numbers are usually in the format: 'A', 'B' or 'C' followed by 5 numbers. E.g. A12345."
       defaultValue={value}
     />
   </FormGroup>

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -281,16 +281,22 @@ const AboutTheVesselSubSection: FunctionComponent<CheckYourAnswersBeaconUseSecti
               value={use.imoNumber}
             />
           )}
-          {use.officialNumber && (
-            <CheckYourAnswersDataRowItem
-              label="Official number"
-              value={use.officialNumber}
-            />
-          )}
           {use.ssrNumber && (
             <CheckYourAnswersDataRowItem
               label="Small Ships Register number"
               value={use.ssrNumber}
+            />
+          )}
+          {use.rssNumber && (
+            <CheckYourAnswersDataRowItem
+              label=" Registry of Shipping and Seamen (RSS) number"
+              value={use.rssNumber}
+            />
+          )}
+          {use.officialNumber && (
+            <CheckYourAnswersDataRowItem
+              label="Official number"
+              value={use.officialNumber}
             />
           )}
           {use.rigPlatformLocation && (

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -55,6 +55,7 @@ export const getMockUse = (): any => ({
   beaconLocation: "In my carry bag",
   imoNumber: "123456",
   ssrNumber: "123456",
+  rssNumber: "123456",
   officialNumber: "123456",
   rigPlatformLocation: "On the rig",
   mainUse: true,

--- a/test/pages/register-a-beacon/about-the-vessel.test.tsx
+++ b/test/pages/register-a-beacon/about-the-vessel.test.tsx
@@ -49,6 +49,10 @@ describe("AboutTheVessel", () => {
         value: "",
         errorMessages: [],
       },
+      rssNumber: {
+        value: "",
+        errorMessages: [],
+      },
       officialNumber: {
         value: "",
         errorMessages: [],


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Wireframe for `about-the-vessel` page has been updated to add a new `RSS number` field for fishing vessels:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/32230328/115855563-48f8af00-a423-11eb-91f1-9e1df72438c2.png">

Wanted to open a PR for it so I don't break anything 😅
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add `RSS number` field to page and `Registration` and update tests 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

I guess the next thing to do is also add this field to the `service`? ~Might need a bit of help with doing that 👀 😬~ In [this PR](https://github.com/mcagov/beacons-service/pull/33)