### PR TITLE
Add callsign tests

### DIFF
--- a/cypress/integration/common/happy-path-test-data.spec.ts
+++ b/cypress/integration/common/happy-path-test-data.spec.ts
@@ -102,6 +102,7 @@ export const testMaritimeUseData = {
     rigPlatformLocation: "Suez Canal",
   },
   communications: {
+    callSign: "C41151GN",
     checkedFields: [
       "vhfRadio",
       "fixedVhfRadio",

--- a/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
@@ -212,6 +212,10 @@ export const iCanSeeMyAviationUse = (purpose: Purpose): void => {
   );
   cy.get("main").contains(testAviationUseData.moreDetails);
   cy.get("main").contains("dongle");
+};
+
+export const iCanSeeMySingleAviationUse = (purpose: Purpose): void => {
+  iCanSeeMyAviationUse(purpose);
   cy.get("main").should("not.contain", "Callsign");
 };
 

--- a/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/aviation.spec.ts
@@ -212,6 +212,7 @@ export const iCanSeeMyAviationUse = (purpose: Purpose): void => {
   );
   cy.get("main").contains(testAviationUseData.moreDetails);
   cy.get("main").contains("dongle");
+  cy.get("main").should("not.contain", "Callsign");
 };
 
 const givenIHaveEnteredInformationAboutMyAircraft = (): void => {

--- a/cypress/integration/common/i-can-enter-use-information/land.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/land.spec.ts
@@ -102,6 +102,7 @@ export const iCanSeeMyLandUse = (): void => {
   cy.get("main").contains(testLandUseData.communications.mobileTelephone2);
   cy.get("main").contains(testLandUseData.communications.otherCommunication);
   cy.get("main").contains(testLandUseData.moreDetails);
+  cy.get("main").should("not.contain", "Callsign");
 };
 
 const givenIHaveEnteredMyLandCommunicationDetails = (): void => {

--- a/cypress/integration/common/i-can-enter-use-information/land.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/land.spec.ts
@@ -102,6 +102,10 @@ export const iCanSeeMyLandUse = (): void => {
   cy.get("main").contains(testLandUseData.communications.mobileTelephone2);
   cy.get("main").contains(testLandUseData.communications.otherCommunication);
   cy.get("main").contains(testLandUseData.moreDetails);
+};
+
+export const iCanSeeMySingleLandUse = (): void => {
+  iCanSeeMyLandUse();
   cy.get("main").should("not.contain", "Callsign");
 };
 

--- a/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
+++ b/cypress/integration/common/i-can-enter-use-information/maritime.spec.ts
@@ -28,6 +28,7 @@ import {
   iAmAt,
   iCanSeeAPageHeadingThatContains,
   thenTheUrlShouldContain,
+  whenIClearTheInput,
   whenIClickBack,
 } from "../selectors-and-assertions.spec";
 import {
@@ -196,6 +197,7 @@ export const iCanEditMyVesselCommunications = (): void => {
   comms.checkedFields.forEach((field) =>
     cy.get(`#${field}`).should("be.checked")
   );
+  cy.get("#callSign").should("have.value", comms.callSign);
   cy.get("#fixedVhfRadioInput").should("have.value", comms.fixedMMSI);
   cy.get("#portableVhfRadioInput").should("have.value", comms.portableMMSI);
   cy.get("#satelliteTelephoneInput").should(
@@ -209,6 +211,7 @@ export const iCanEditMyVesselCommunications = (): void => {
 
 export const iCanChangeMyVesselCommunications = (): void => {
   const comms = testMaritimeUseData.communications;
+  whenIClearTheInput("#callSign");
   comms.checkedFields.forEach((field) => givenIHaveUnselected(`#${field}`));
 };
 
@@ -294,6 +297,7 @@ export const givenIHaveEnteredRequiredInformationAboutMyVessel = (): void => {
 
 export const givenIHaveEnteredMyVesselCommunicationDetails = (): void => {
   const comms = testMaritimeUseData.communications;
+  givenIHaveTyped(comms.callSign, "#callSign");
   givenIHaveSelected("#vhfRadio");
   givenIHaveSelected("#fixedVhfRadio");
   givenIHaveTyped(comms.fixedMMSI, "#fixedVhfRadioInput");

--- a/cypress/integration/common/selectors-and-assertions.spec.ts
+++ b/cypress/integration/common/selectors-and-assertions.spec.ts
@@ -69,6 +69,10 @@ export const whenIType = (value: string, selector: string): void => {
 export const givenIHaveTyped = whenIType;
 export const andIType = whenIType;
 
+export const whenIClearTheInput = (selector: string): void => {
+  cy.get(selector).clear();
+};
+
 export const thenTheUrlShouldContain = (urlPath: string): void => {
   cy.url().should("include", urlPath);
 };

--- a/cypress/integration/single-beacon-owner/i-can-register-a-land-beacon.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-land-beacon.spec.ts
@@ -32,7 +32,7 @@ import {
   iCanEditMyAdditionalLandUseMoreDetails,
   iCanEditMyLandActivity,
   iCanEditMyLandCommunications,
-  iCanSeeMyLandUse,
+  iCanSeeMySingleLandUse,
   iCanViewMyChangedLandCommunications,
 } from "../common/i-can-enter-use-information/land.spec";
 import {
@@ -55,7 +55,7 @@ describe("As a land beacon owner", () => {
     thenTheUrlShouldContain(PageURLs.checkYourAnswers);
     iCanSeeMyBeaconDetails();
     iCanSeeMyAdditionalBeaconInformation();
-    iCanSeeMyLandUse();
+    iCanSeeMySingleLandUse();
     iCanSeeMyPersonalDetails();
     iCanSeeMyAddressDetails();
     iCanSeeMyEmergencyContactDetails();

--- a/cypress/integration/single-beacon-owner/i-can-register-an-aviation-beacon.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-an-aviation-beacon.spec.ts
@@ -16,7 +16,7 @@ import {
 import {
   givenIHaveEnteredMyAviationUse,
   iCanGoBackAndEditMyAviationUse,
-  iCanSeeMyAviationUse,
+  iCanSeeMySingleAviationUse,
 } from "../common/i-can-enter-use-information/aviation.spec";
 import { andIHaveNoFurtherUses } from "../common/i-can-enter-use-information/generic.spec";
 import { thenTheUrlShouldContain } from "../common/selectors-and-assertions.spec";
@@ -34,7 +34,7 @@ describe("As an aviation beacon owner,", () => {
     thenTheUrlShouldContain(PageURLs.checkYourAnswers);
     iCanSeeMyBeaconDetails();
     iCanSeeMyAdditionalBeaconInformation();
-    iCanSeeMyAviationUse(Purpose.PLEASURE);
+    iCanSeeMySingleAviationUse(Purpose.PLEASURE);
     iCanSeeMyPersonalDetails();
     iCanSeeMyAddressDetails();
     iCanSeeMyEmergencyContactDetails();
@@ -53,7 +53,7 @@ describe("As an aviation beacon owner,", () => {
     thenTheUrlShouldContain(PageURLs.checkYourAnswers);
     iCanSeeMyBeaconDetails();
     iCanSeeMyAdditionalBeaconInformation();
-    iCanSeeMyAviationUse(Purpose.COMMERCIAL);
+    iCanSeeMySingleAviationUse(Purpose.COMMERCIAL);
     iCanSeeMyPersonalDetails();
     iCanSeeMyAddressDetails();
     iCanSeeMyEmergencyContactDetails();


### PR DESCRIPTION
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Added tests to check that Callsign is only shown on the Check your answers page for `Maritime` use
   - This was fixed in #253 but we didn't have any tests around it
   
- Also saw that we didn't really have any tests/assertions for the Callsign input so added some for `Maritime` use

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/M4GjQJuZ/536-bug-beta-user-goes-through-second-use-land-communications-page-no-call-sign-listed-as-an-option-but-visible-with-no-data-entered

