### PR TITLE
Revert "Bump sass from 1.32.12 to 1.34.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10114,9 +10114,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.34.0.tgz",
-      "integrity": "sha512-rHEN0BscqjUYuomUEaqq3BMgsXqQfkcMVR7UhscsAVub0/spUrZGBMxQXFS2kfiDsPLZw5yuU9iJEFNC2x38Qw==",
+      "version": "1.32.12",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
+      "integrity": "sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "2.2.1",
     "prettier-plugin-organize-imports": "^2.0.0",
     "pretty-quick": "^3.1.0",
-    "sass": "^1.34.0",
+    "sass": "^1.32.12",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   },


### PR DESCRIPTION
Reverts mcagov/beacons-webapp#269

Due to deprecation warnings in `sass` library, see: https://sass-lang.com/documentation/breaking-changes/slash-div

See open issue on Gov Frontend: https://github.com/alphagov/govuk-frontend/issues/2238