### PR TITLE
Add getAccountHolderDetails endpoint

### DIFF
--- a/src/gateways/accountHolderApiGateway.ts
+++ b/src/gateways/accountHolderApiGateway.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosResponse } from "axios";
+import { IAccountHolderDetailsResponseBody } from "../lib/accountHolder/accountHolderDetailsResponseBody";
 import { IAccountHolderIdResponseBody } from "../lib/accountHolder/accountHolderIdResponseBody";
 
 export class AccountHolderApiGateway {
   private readonly apiUrl: string;
   private readonly accountHolderIdEndpoint = "account-holder/auth-id";
+  private readonly accountHolderDetailsEndpoint = "account-holder";
 
   constructor() {
     this.apiUrl = process.env.API_URL;
@@ -22,6 +24,28 @@ export class AccountHolderApiGateway {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       return response.data.id;
+    } catch (error) {
+      /* eslint-disable no-console */
+      console.error(JSON.stringify(error));
+      throw error;
+    }
+  }
+
+  public async getAccountHolderDetails(
+    accountHolderId: string,
+    accessToken: string
+  ): Promise<IAccountHolderDetailsResponseBody> {
+    const url = `${this.apiUrl}/${this.accountHolderDetailsEndpoint}/${accountHolderId}`;
+    try {
+      const response = await axios.get<
+        any,
+        AxiosResponse<IAccountHolderDetailsResponseBody>
+      >(url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+
+      console.log("response", response);
+      return response.data;
     } catch (error) {
       /* eslint-disable no-console */
       console.error(JSON.stringify(error));

--- a/src/gateways/accountHolderApiGateway.ts
+++ b/src/gateways/accountHolderApiGateway.ts
@@ -44,7 +44,6 @@ export class AccountHolderApiGateway {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
 
-      console.log("response", response);
       return response.data;
     } catch (error) {
       /* eslint-disable no-console */

--- a/src/lib/accountHolder/accountHolderDetailsResponseBody.ts
+++ b/src/lib/accountHolder/accountHolderDetailsResponseBody.ts
@@ -1,0 +1,14 @@
+export interface IAccountHolderDetailsResponseBody {
+  id: string;
+  fullName: string;
+  email: string;
+  telephoneNumber: string;
+  alternativeTelephoneNumber: string;
+  addressLine1: string;
+  addressLine2: string;
+  addressLine3: string;
+  addressLine4: string;
+  townOrCity: string;
+  county: string;
+  postcode: string;
+}

--- a/test/gateways/accountHolderApiGateway.test.ts
+++ b/test/gateways/accountHolderApiGateway.test.ts
@@ -1,31 +1,28 @@
 import axios from "axios";
 import { v4 } from "uuid";
 import { AccountHolderApiGateway } from "../../src/gateways/accountHolderApiGateway";
+import { IAccountHolderDetailsResponseBody } from "../../src/lib/accountHolder/accountHolderDetailsResponseBody";
 
 jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("Account Holder API Gateway", () => {
   let gateway: AccountHolderApiGateway;
-  const endpoint = "account-holder/auth-id";
+  const accountHolderIdEndpoint = "account-holder/auth-id";
+  const accountHolderDetailsEndpoint = "account-holder";
+  let authId;
+  let accountHolderId;
+  let token;
 
-  beforeEach(() => {
-    gateway = new AccountHolderApiGateway();
-  });
-
-  describe("Getting an account holder", () => {
-    let authId;
-    let acountHolderId;
-    let token;
-
+  describe("Getting an account holder id from an auth id", () => {
     beforeEach(() => {
       authId = v4();
-      acountHolderId = v4();
       token = v4();
+      gateway = new AccountHolderApiGateway();
     });
 
     it("should request an accountHolderId from the correct endpoint", async () => {
-      const expectedUrl = `${process.env.API_URL}/${endpoint}/${authId}`;
+      const expectedUrl = `${process.env.API_URL}/${accountHolderIdEndpoint}/${authId}`;
       mockedAxios.get.mockResolvedValue({
         data: {
           id: "any id",
@@ -34,7 +31,7 @@ describe("Account Holder API Gateway", () => {
 
       await gateway.getAccountHolderId(authId, token);
 
-      expect((axios as any).get).toHaveBeenLastCalledWith(expectedUrl, {
+      expect(mockedAxios.get).toHaveBeenLastCalledWith(expectedUrl, {
         headers: { Authorization: `Bearer ${token}` },
       });
     });
@@ -42,19 +39,69 @@ describe("Account Holder API Gateway", () => {
     it("should return the obtained accountHolderId from the API", async () => {
       mockedAxios.get.mockResolvedValue({
         data: {
-          id: acountHolderId,
+          id: accountHolderId,
         },
       });
 
-      const expected = await gateway.getAccountHolderId(authId, token);
+      const result = await gateway.getAccountHolderId(authId, token);
 
-      expect(expected).toBe(acountHolderId);
+      expect(result).toBe(accountHolderId);
     });
 
     it("should allow errors to bubble up", async () => {
       jest.spyOn(console, "error").mockReturnValue();
       mockedAxios.get.mockImplementationOnce(() => Promise.reject(new Error()));
       const call = () => gateway.getAccountHolderId(authId, token);
+
+      expect(call).rejects.toThrow();
+    });
+  });
+
+  describe("Getting an account holder details", () => {
+    beforeEach(() => {
+      accountHolderId = v4();
+      token = v4();
+      gateway = new AccountHolderApiGateway();
+    });
+
+    it("should request account holder details from the correct endpoint", async () => {
+      const expectedUrl = `${process.env.API_URL}/${accountHolderDetailsEndpoint}/${accountHolderId}`;
+      await gateway.getAccountHolderDetails(accountHolderId, token);
+
+      expect(mockedAxios.get).toHaveBeenLastCalledWith(expectedUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    });
+
+    it("should return account holder details", async () => {
+      const expected = {
+        id: "number-1",
+        fullName: "Bill Gates",
+        email: "bill@billynomates.test",
+        telephoneNumber: "0788888888",
+        alternativeTelephoneNumber: "NA",
+        addressLine1: "Evil Lair",
+        addressLine2: "1 Microsoft Square",
+        addressLine3: "",
+        addressLine4: "",
+        townOrCity: "Googleville",
+        county: "Lancs",
+        postcode: "ZX80 CPC",
+      };
+      mockedAxios.get.mockResolvedValue({ data: { ...expected } });
+
+      const result = await gateway.getAccountHolderDetails(
+        accountHolderId,
+        token
+      );
+      expect(result).toMatchObject<IAccountHolderDetailsResponseBody>(expected);
+    });
+
+    it("should allow errors to bubble up", async () => {
+      jest.spyOn(console, "error").mockReturnValue();
+      mockedAxios.get.mockImplementationOnce(() => Promise.reject(new Error()));
+      const call = () =>
+        gateway.getAccountHolderDetails(accountHolderId, token);
 
       expect(call).rejects.toThrow();
     });

--- a/test/gateways/accountHolderApiGateway.test.ts
+++ b/test/gateways/accountHolderApiGateway.test.ts
@@ -8,13 +8,11 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("Account Holder API Gateway", () => {
   let gateway: AccountHolderApiGateway;
-  const accountHolderIdEndpoint = "account-holder/auth-id";
-  const accountHolderDetailsEndpoint = "account-holder";
-  let authId;
-  let accountHolderId;
   let token;
 
   describe("Getting an account holder id from an auth id", () => {
+    const accountHolderIdEndpoint = "account-holder/auth-id";
+    let authId;
     beforeEach(() => {
       authId = v4();
       token = v4();
@@ -39,13 +37,13 @@ describe("Account Holder API Gateway", () => {
     it("should return the obtained accountHolderId from the API", async () => {
       mockedAxios.get.mockResolvedValue({
         data: {
-          id: accountHolderId,
+          id: "any-account-holder-id",
         },
       });
 
       const result = await gateway.getAccountHolderId(authId, token);
 
-      expect(result).toBe(accountHolderId);
+      expect(result).toBe("any-account-holder-id");
     });
 
     it("should allow errors to bubble up", async () => {
@@ -58,6 +56,9 @@ describe("Account Holder API Gateway", () => {
   });
 
   describe("Getting an account holder details", () => {
+    const accountHolderDetailsEndpoint = "account-holder";
+    let accountHolderId;
+
     beforeEach(() => {
       accountHolderId = v4();
       token = v4();
@@ -75,7 +76,7 @@ describe("Account Holder API Gateway", () => {
 
     it("should return account holder details", async () => {
       const expected = {
-        id: "number-1",
+        id: accountHolderId,
         fullName: "Bill Gates",
         email: "bill@billynomates.test",
         telephoneNumber: "0788888888",


### PR DESCRIPTION
## Context

We need to get the account holder details from the API to display on the beacon list page.

## Changes in this pull request
accountHolderApiGateway.ts - added call to account holder details endpoint
accountHolderDetailsResponseBody.ts  - response body for the above
accountHolderApiGateway.test.ts - tests for the above

## Guidance to review

not currently consumed anywhere

## Link to Trello card
https://trello.com/c/hXUrPh0h/672-frontend-beacon-account-holder-user-can-view-list-of-registered-beacons

