### PR TITLE
Added return to your account section and button to application-comple…

### DIFF
--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
+import { LinkButton } from "../../components/Button";
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { Panel } from "../../components/Panel";
@@ -52,6 +53,7 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
                   381 72630.
                 </GovUKBody>
               </WarningText>
+              <ApplicationCompleteYourBeaconRegistryAccount />
             </>
           }
         />
@@ -73,6 +75,17 @@ const ApplicationCompleteWhatNext: FunctionComponent = (): JSX.Element => (
     </GovUKBody>
   </>
 );
+
+const ApplicationCompleteYourBeaconRegistryAccount: FunctionComponent =
+  (): JSX.Element => (
+    <>
+      <SectionHeading>Your Beacon Registry Account</SectionHeading>
+      <LinkButton
+        buttonText="Return to your Account"
+        href={PageURLs.accountHome}
+      />
+    </>
+  );
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   async (context: BeaconsGetServerSidePropsContext) => {


### PR DESCRIPTION
## Context

Added button to application-complete page to take the user to the account holder page

## Changes in this pull request

application-complete.tsx - Section with button added to get to account holder page

Before:
![Screenshot 2021-06-24 at 15 39 19](https://user-images.githubusercontent.com/85493169/123282560-87cde280-d502-11eb-83d8-d43e0dd2f520.png)

After:
![Screenshot 2021-06-24 at 15 40 32](https://user-images.githubusercontent.com/85493169/123282571-8b616980-d502-11eb-8afd-f8ed7c163d14.png)

## Guidance to review

Directly going to http://localhost:3000/register-a-beacon/application-complete is the easiest way to view the change. You also can go through the flow of adding a beacon instead though.

## Link to Trello card

https://trello.com/c/zAstjCgX/736-beacon-account-holder-user-can-add-new-beacon

## Things to check

- [x] Spelling is correct and to the design
