### PR TITLE
Account id in beacon registration 

### DIFF
--- a/src/lib/appContainer.ts
+++ b/src/lib/appContainer.ts
@@ -30,6 +30,10 @@ import {
   GetBeaconsByAccountHolderIdFn,
 } from "../useCases/getAccountBeacons";
 import {
+  getAccountHolderId,
+  GetAccountHolderIdFn,
+} from "../useCases/getAccountHolderId";
+import {
   getCachedRegistration,
   GetCachedRegistrationFn,
 } from "../useCases/getCachedRegistration";
@@ -57,6 +61,7 @@ export interface IAppContainer {
   getAccessToken: GetAccessTokenFn;
   getSession: GetSessionFn;
   getOrCreateAccountHolder: GetOrCreateAccountHolderFn;
+  getAccountHolderId: GetAccountHolderIdFn;
   getBeaconsByAccountHolderId: GetBeaconsByAccountHolderIdFn;
 
   /* Gateways */
@@ -90,6 +95,9 @@ export const getAppContainer = (overrides?: IAppContainer): IAppContainer => {
     },
     get getOrCreateAccountHolder() {
       return getOrCreateAccountHolder(this);
+    },
+    get getAccountHolderId() {
+      return getAccountHolderId(this);
     },
     get getBeaconsByAccountHolderId() {
       return getBeaconsByAccountHolderId(this);

--- a/src/lib/registration/registration.ts
+++ b/src/lib/registration/registration.ts
@@ -97,6 +97,7 @@ export class Registration {
       model: registration.model,
       hexId: registration.hexId,
       referenceNumber: registration.referenceNumber,
+      accountHolderId: registration.accountHolderId,
 
       manufacturerSerialNumber: registration.manufacturerSerialNumber,
       chkCode: registration.chkCode,

--- a/src/lib/registration/registration.ts
+++ b/src/lib/registration/registration.ts
@@ -47,6 +47,10 @@ export class Registration {
     this.registration.referenceNumber = referenceNumber;
   }
 
+  public setAccountHolderId(accountHolderId: string): void {
+    this.registration.accountHolderId = accountHolderId;
+  }
+
   private _updateBeacon(formData: FormSubmission): void {
     Object.keys(formData)
       .filter((key: string) => !(key === Registration.USES_KEY))

--- a/src/lib/registration/registrationInitialisation.ts
+++ b/src/lib/registration/registrationInitialisation.ts
@@ -10,6 +10,7 @@ export const initBeacon = (): IRegistration => {
     manufacturer: "",
     model: "",
     hexId: "",
+    accountHolderId: "",
 
     referenceNumber: "",
 

--- a/src/lib/registration/types.ts
+++ b/src/lib/registration/types.ts
@@ -3,6 +3,7 @@ export interface IRegistration {
   model: string;
   hexId: string;
   referenceNumber: string;
+  accountHolderId: string;
 
   manufacturerSerialNumber: string;
   chkCode: string;

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -15,11 +15,7 @@ import { redirectUserTo } from "../../lib/redirectUserTo";
 import { retrieveUserFormSubmissionId } from "../../lib/retrieveUserFormSubmissionId";
 import { PageURLs } from "../../lib/urls";
 import { verifyFormSubmissionCookieIsSet } from "../../lib/verifyFormSubmissionCookieIsSet";
-import { getAccountHolderId } from "../../useCases/getAccountHolderId";
-import {
-  ISubmitRegistrationResult,
-  submitRegistration,
-} from "../../useCases/submitRegistration";
+import { ISubmitRegistrationResult } from "../../useCases/submitRegistration";
 
 interface ApplicationCompleteProps {
   reference: string;
@@ -93,18 +89,17 @@ const ApplicationCompleteYourBeaconRegistryAccount: FunctionComponent =
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   async (context: BeaconsGetServerSidePropsContext) => {
+    /* Retrieve injected use case(s) */
+    const { submitRegistration, getAccountHolderId } = context.container;
+
     /* Page logic */
     if (!verifyFormSubmissionCookieIsSet(context))
       return redirectUserTo(PageURLs.start);
 
     try {
-      const accountHolderId = await getAccountHolderId(context.container)(
-        context
-      );
-      const registration = retrieveUserFormSubmissionId(context);
-      const result = await submitRegistration(context.container)(
-        registration,
-        accountHolderId
+      const result = await submitRegistration(
+        retrieveUserFormSubmissionId(context),
+        await getAccountHolderId(context)
       );
 
       const pageSubHeading = (result: ISubmitRegistrationResult) => {

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -15,7 +15,11 @@ import { redirectUserTo } from "../../lib/redirectUserTo";
 import { retrieveUserFormSubmissionId } from "../../lib/retrieveUserFormSubmissionId";
 import { PageURLs } from "../../lib/urls";
 import { verifyFormSubmissionCookieIsSet } from "../../lib/verifyFormSubmissionCookieIsSet";
-import { ISubmitRegistrationResult } from "../../useCases/submitRegistration";
+import { getAccountHolderId } from "../../useCases/getAccountHolderId";
+import {
+  ISubmitRegistrationResult,
+  submitRegistration,
+} from "../../useCases/submitRegistration";
 
 interface ApplicationCompleteProps {
   reference: string;
@@ -89,16 +93,18 @@ const ApplicationCompleteYourBeaconRegistryAccount: FunctionComponent =
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   async (context: BeaconsGetServerSidePropsContext) => {
-    /* Retrieve injected use case(s) */
-    const { submitRegistration } = context.container;
-
     /* Page logic */
     if (!verifyFormSubmissionCookieIsSet(context))
       return redirectUserTo(PageURLs.start);
 
     try {
-      const result = await submitRegistration(
-        retrieveUserFormSubmissionId(context)
+      const accountHolderId = await getAccountHolderId(context.container)(
+        context
+      );
+      const registration = retrieveUserFormSubmissionId(context);
+      const result = await submitRegistration(context.container)(
+        registration,
+        accountHolderId
       );
 
       const pageSubHeading = (result: ISubmitRegistrationResult) => {

--- a/src/useCases/submitRegistration.ts
+++ b/src/useCases/submitRegistration.ts
@@ -2,7 +2,8 @@ import { IAppContainer } from "../lib/appContainer";
 import { referenceNumber } from "../lib/utils";
 
 export type SubmitRegistrationFn = (
-  submissionId: string
+  submissionId: string,
+  accountHolderId: string
 ) => Promise<ISubmitRegistrationResult>;
 
 export interface ISubmitRegistrationResult {
@@ -18,11 +19,12 @@ export const submitRegistration =
     getAccessToken,
     beaconsApiGateway,
   }: Partial<IAppContainer>): SubmitRegistrationFn =>
-  async (submissionId) => {
+  async (submissionId: string, accountHolderId: string) => {
     const registration = await getCachedRegistration(submissionId);
     const accessToken = await getAccessToken();
 
     registration.setReferenceNumber(referenceNumber("A#", 7));
+    registration.setAccountHolderId(accountHolderId);
 
     const beaconRegistered = await beaconsApiGateway.sendRegistration(
       registration.serialiseToAPI(),

--- a/test/pages/register-a-beacon/application-complete.test.tsx
+++ b/test/pages/register-a-beacon/application-complete.test.tsx
@@ -26,6 +26,7 @@ describe("ApplicationCompletePage", () => {
     beforeEach(() => {
       mockContainer = {
         submitRegistration: mockSubmitRegistration,
+        getAccountHolderId: jest.fn().mockResolvedValue("account-holder-id"),
       };
     });
 
@@ -48,6 +49,7 @@ describe("ApplicationCompletePage", () => {
 
     it("should attempt to submit the user's registration", async () => {
       const userRegistrationId = "user-form-submission-cookie-id";
+      const accountHolderId = "account-holder-id";
       const context = {
         req: {
           cookies: { [formSubmissionCookieId]: userRegistrationId },
@@ -58,7 +60,10 @@ describe("ApplicationCompletePage", () => {
 
       await getServerSideProps(context as any);
 
-      expect(mockSubmitRegistration).toHaveBeenCalledWith(userRegistrationId);
+      expect(mockSubmitRegistration).toHaveBeenCalledWith(
+        userRegistrationId,
+        accountHolderId
+      );
     });
 
     it("should not return a reference number if creating the registration is unsuccessful", async () => {
@@ -92,7 +97,7 @@ describe("ApplicationCompletePage", () => {
       };
       mockSubmitRegistration.mockResolvedValue(successful);
 
-      const result = await getServerSideProps(context.container)(context);
+      const result = await getServerSideProps(context as any);
 
       expect(result.props.reference).toBe("ABC123");
     });

--- a/test/pages/register-a-beacon/application-complete.test.tsx
+++ b/test/pages/register-a-beacon/application-complete.test.tsx
@@ -92,7 +92,7 @@ describe("ApplicationCompletePage", () => {
       };
       mockSubmitRegistration.mockResolvedValue(successful);
 
-      const result = await getServerSideProps(context);
+      const result = await getServerSideProps(context.container)(context);
 
       expect(result.props.reference).toBe("ABC123");
     });

--- a/test/useCases/submitRegistration.test.ts
+++ b/test/useCases/submitRegistration.test.ts
@@ -5,6 +5,7 @@ describe("submitRegistration()", () => {
   const mockRegistration = {
     serialiseToAPI: jest.fn().mockReturnValue({ model: "ASOS" }),
     setReferenceNumber: jest.fn(),
+    setAccountHolderId: jest.fn(),
     getRegistration: jest.fn().mockReturnValue({ model: "ASOS" }),
   };
 

--- a/test/useCases/submitRegistration.test.ts
+++ b/test/useCases/submitRegistration.test.ts
@@ -19,7 +19,7 @@ describe("submitRegistration()", () => {
       },
     };
 
-    await submitRegistration(container)("submissionId");
+    await submitRegistration(container)("submissionId", "accountHolderId");
 
     expect(mockRetrieveAuthToken).toHaveBeenCalledTimes(1);
   });
@@ -35,7 +35,7 @@ describe("submitRegistration()", () => {
       },
     };
 
-    await submitRegistration(container)("submissionId");
+    await submitRegistration(container)("submissionId", "accountHolderId");
 
     expect(mockSendRegistrationToApi).toHaveBeenCalledTimes(1);
   });
@@ -52,7 +52,39 @@ describe("submitRegistration()", () => {
       },
     };
 
-    await submitRegistration(container)("submissionId");
+    await submitRegistration(container)("submissionId", "accountHolderId");
+
+    expect(mockRegistration.setReferenceNumber).toHaveBeenCalled();
+  });
+
+  it("sets the account holder id before sending to the beacons API", async () => {
+    const mockSendRegistrationToApi = jest.fn();
+    const container: Partial<IAppContainer> = {
+      getCachedRegistration: jest.fn().mockResolvedValue(mockRegistration),
+      getAccessToken: jest.fn(),
+      sendConfirmationEmail: jest.fn(),
+      beaconsApiGateway: {
+        sendRegistration: mockSendRegistrationToApi,
+      },
+    };
+
+    await submitRegistration(container)("submissionId", "accountHolderId");
+
+    expect(mockRegistration.setReferenceNumber).toHaveBeenCalled();
+  });
+
+  it("account holder id accepts null value without throwing", async () => {
+    const mockSendRegistrationToApi = jest.fn();
+    const container: Partial<IAppContainer> = {
+      getCachedRegistration: jest.fn().mockResolvedValue(mockRegistration),
+      getAccessToken: jest.fn(),
+      sendConfirmationEmail: jest.fn(),
+      beaconsApiGateway: {
+        sendRegistration: mockSendRegistrationToApi,
+      },
+    };
+
+    await submitRegistration(container)("submissionId", null);
 
     expect(mockRegistration.setReferenceNumber).toHaveBeenCalled();
   });
@@ -68,7 +100,7 @@ describe("submitRegistration()", () => {
       },
     };
 
-    await submitRegistration(container)("submissionId");
+    await submitRegistration(container)("submissionId", "accountHolderId");
 
     expect(mockSendConfirmationEmail).toHaveBeenCalledTimes(1);
   });
@@ -83,7 +115,10 @@ describe("submitRegistration()", () => {
       },
     };
 
-    const result = await submitRegistration(container)("submissionId");
+    const result = await submitRegistration(container)(
+      "submissionId",
+      "accountHolderId"
+    );
 
     expect(result).toStrictEqual({
       beaconRegistered: true,
@@ -102,7 +137,10 @@ describe("submitRegistration()", () => {
       },
     };
 
-    const result = await submitRegistration(container)("submissionId");
+    const result = await submitRegistration(container)(
+      "submissionId",
+      "accountHolderId"
+    );
 
     expect(result).toStrictEqual({
       beaconRegistered: true,
@@ -124,7 +162,10 @@ describe("submitRegistration()", () => {
       },
     };
 
-    const result = await submitRegistration(container)("submissionId");
+    const result = await submitRegistration(container)(
+      "submissionId",
+      "accountHolderId"
+    );
 
     expect(result.referenceNumber.length).toBeDefined();
   });
@@ -139,7 +180,10 @@ describe("submitRegistration()", () => {
       },
     };
 
-    const result = await submitRegistration(container)("submissionId");
+    const result = await submitRegistration(container)(
+      "submissionId",
+      "accountHolderId"
+    );
 
     expect(result.referenceNumber).toEqual("");
   });


### PR DESCRIPTION
## Context

When submitting a registration we now include the account holder id

## Changes in this pull request

- added **GetAccountHolderId** use case.
- **registration.ts** now has an account holder id property
- **application-complete.tsx** gets account holder id and passes along to submission
- **submitRegistration.ts** now takes an account holder id and sets it on the reg object
- **submitRegistration.test.ts** added a test to check account holder id is being passed through

## Guidance to review

complete the form and a beacon will be shown on your account :) 

