### PR TITLE
update create account holder to create with email address

### DIFF
--- a/src/gateways/accountHolderApiGateway.ts
+++ b/src/gateways/accountHolderApiGateway.ts
@@ -9,6 +9,7 @@ import { BeaconResponseMapper } from "./mappers/beaconResponseMapper";
 export interface IAccountHolderApiGateway {
   createAccountHolder(
     authId: string,
+    email: string,
     accessToken: string
   ): Promise<IAccountHolderDetails>;
   getAccountHolderId(authId: string, accessToken: string): Promise<string>;
@@ -56,12 +57,13 @@ export class AccountHolderApiGateway implements IAccountHolderApiGateway {
 
   public async createAccountHolder(
     authId: string,
+    email: string,
     accessToken: string
   ): Promise<IAccountHolderDetails> {
     const url = `${this.apiUrl}/${this.accountHolderControllerRoute}`;
     try {
       const request = {
-        data: { attributes: { authId } },
+        data: { attributes: { authId, email } },
       } as IAccountHolderDetailsResponse;
       const response = await axios.post<
         any,

--- a/src/useCases/getOrCreateAccountHolder.ts
+++ b/src/useCases/getOrCreateAccountHolder.ts
@@ -15,6 +15,7 @@ export const getOrCreateAccountHolder =
   async (context: BeaconsGetServerSidePropsContext) => {
     const session = await getSession(context);
     const authId: string = session.user.authId;
+    const email: string = session.user.email;
     const accessToken = await getAccessToken();
 
     const accountHolderId = await accountHolderApiGateway.getAccountHolderId(
@@ -30,6 +31,7 @@ export const getOrCreateAccountHolder =
 
     return await accountHolderApiGateway.createAccountHolder(
       authId,
+      email,
       accessToken
     );
   };

--- a/test/gateways/accountHolderApiGateway.test.ts
+++ b/test/gateways/accountHolderApiGateway.test.ts
@@ -13,6 +13,7 @@ describe("Account Holder API Gateway", () => {
 
   describe("Creating an account holder from a provided auth id", () => {
     const authId = v4();
+    const email = authId + "@madetech.com";
     const accessToken = v4();
     gateway = new AccountHolderApiGateway(hostName);
 
@@ -20,7 +21,7 @@ describe("Account Holder API Gateway", () => {
       const createAccountHolderEndpoint = "account-holder";
       const expectedUrl = `${hostName}/${createAccountHolderEndpoint}`;
       const expectedRequest = {
-        data: { attributes: { authId } },
+        data: { attributes: { authId, email } },
       };
       const expectedHeaders = {
         headers: { Authorization: `Bearer ${accessToken}` },
@@ -33,7 +34,7 @@ describe("Account Holder API Gateway", () => {
         },
       });
 
-      gateway.createAccountHolder(authId, accessToken);
+      gateway.createAccountHolder(authId, email, accessToken);
 
       expect(mockedAxios.post).toHaveBeenCalledWith(
         expectedUrl,
@@ -47,6 +48,7 @@ describe("Account Holder API Gateway", () => {
       const testFullName = "Adut Akech";
       const expectedAccountHolder: Partial<IAccountHolderDetails> = {
         id: tesId,
+        email: email,
         fullName: testFullName,
       };
       mockedAxios.post.mockResolvedValue({
@@ -55,6 +57,7 @@ describe("Account Holder API Gateway", () => {
             id: tesId,
             attributes: {
               fullName: testFullName,
+              email: email,
             },
           },
         },
@@ -62,6 +65,7 @@ describe("Account Holder API Gateway", () => {
 
       const createdAccountHolder = await gateway.createAccountHolder(
         authId,
+        email,
         accessToken
       );
       expect(createdAccountHolder).toEqual(expectedAccountHolder);


### PR DESCRIPTION
## Context

when a user signs in for the first time we need to capture the user email

## Changes in this pull request

* pull the email out of the session
* pop it on the create account request
* winning!

Also updated tests with new method signatures.

## Guidance to review

your login email here...
![image](https://user-images.githubusercontent.com/14999594/124574402-58906d00-de42-11eb-899c-d50505d41a66.png)

## Link to Trello card

https://trello.com/c/Uowf65bt/683-api-beacon-account-holder-user-can-update-profile-details-on-beacon-api

