### PR TITLE
Delete cached beacon use 2

### DIFF
--- a/cypress/integration/common/selectors-and-assertions.spec.ts
+++ b/cypress/integration/common/selectors-and-assertions.spec.ts
@@ -65,6 +65,9 @@ export const givenIHaveClickedTheButtonContaining = (text: string): void => {
 export const andIClickTheButtonContaining =
   givenIHaveClickedTheButtonContaining;
 
+export const whenIClickTheButtonContaining =
+  givenIHaveClickedTheButtonContaining;
+
 export const whenIClickContinue = (): void => {
   givenIHaveClickedTheButtonContaining("Continue");
 };

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -44,7 +44,7 @@ describe("As a beacon owner with several uses", () => {
 const iCanSeeMyMainUse = () => iCanSeeMyLandUse();
 
 const myThirdUseIsNowMySecondUse = () =>
-  cy.get("h2").contains(/third use/i && /aviation/i && /commercial/i);
+  cy.get("h2").contains(/(?=.*second use)(?=.*aviation)(?=.*commercial)/i);
 
 const givenIHaveThreeUses = () => {
   givenIHaveEnteredMyBeaconDetails();
@@ -64,7 +64,7 @@ const iCanSeeMyThreeUses = () => {
 const iCannotSeeWhatWasMySecondUseBecauseItIsDeleted = () =>
   cy
     .get("main")
-    .contains(/maritime/i && /motor/i && /pleasure/i)
+    .contains(/(?=.*maritime)(?=.*motor)(?=.*pleasure)/i)
     .should("not.exist");
 
 const whenIGoToDeleteMyMainUse = () =>
@@ -84,11 +84,11 @@ const whenIGoToDeleteMySecondUse = () =>
     .click();
 
 const thenIAmPromptedToConfirmDeletionOfMyMainUse = () =>
-  cy.get("h1").contains(/are you sure/i && /land/i && /cycling/i);
+  cy.get("h1").contains(/(?=.*are you sure)(?=.*land)(?=.*cycling)/i);
 
 const iAmPromptedToConfirmDeletionOfMySecondUse = () =>
   cy
     .get("h1")
-    .contains(/are you sure/i && /maritime/i && /motor/i && /pleasure/i);
+    .contains(/(?=.*are you sure)(?=.*maritime)(?=.*motor)(?=.*pleasure)/i);
 
 const iAmEditingWhatIsNowMySecondUse = iCanEditMyAdditionalLandUseMoreDetails;

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -1,75 +1,93 @@
 import { Purpose } from "../../../src/lib/registration/types";
 import { givenIHaveEnteredMyBeaconDetails } from "../common/i-can-enter-beacon-information.spec";
+import {
+  givenIHaveEnteredMyAviationUse,
+  iCanSeeMyAviationUse,
+} from "../common/i-can-enter-use-information/aviation.spec";
 import { andIHaveAnotherUse } from "../common/i-can-enter-use-information/generic.spec";
 import {
   givenIHaveEnteredMyLandUse,
+  iCanEditMyAdditionalLandUseMoreDetails,
   iCanSeeMyLandUse,
 } from "../common/i-can-enter-use-information/land.spec";
 import {
   givenIHaveEnteredMyMaritimeUse,
   iCanSeeMyMaritimeUse,
 } from "../common/i-can-enter-use-information/maritime.spec";
-import { givenIHaveClickedTheButtonContaining } from "../common/selectors-and-assertions.spec";
+import {
+  givenIHaveClickedTheButtonContaining,
+  whenIClickBack,
+} from "../common/selectors-and-assertions.spec";
 
 describe("As a beacon owner with several uses", () => {
   it("I can safely remove a use from my draft registration", () => {
-    givenIHaveTwoUses();
+    givenIHaveThreeUses();
     andIGoToDeleteMyMainUse();
     iAmPromptedToConfirmDeletionOfMyMainUse();
 
     givenIHaveClickedTheButtonContaining("Cancel");
-    iCanSeeMyTwoUses();
+    iCanSeeMyThreeUses();
     andIGoToDeleteMySecondUse();
     iAmPromptedToConfirmDeletionOfMySecondUse();
 
     givenIHaveClickedTheButtonContaining("Yes");
     iCanSeeMyMainUse();
-    iCannotSeeMySecondUseBecauseItIsDeleted();
+    iCannotSeeWhatWasMySecondUseBecauseItIsDeleted();
+    myThirdUseIsNowMySecondUse();
+
+    whenIClickBack();
+    iAmEditingWhatIsNowMySecondUse();
   });
 });
 
 const iCanSeeMyMainUse = () => iCanSeeMyLandUse();
 
-const givenIHaveTwoUses = () => {
+const myThirdUseIsNowMySecondUse = () =>
+  cy.get("h2").contains(/third use/i && /aviation/i && /commercial/i);
+
+const givenIHaveThreeUses = () => {
   givenIHaveEnteredMyBeaconDetails();
   givenIHaveEnteredMyLandUse();
   andIHaveAnotherUse();
   givenIHaveEnteredMyMaritimeUse(Purpose.PLEASURE);
+  andIHaveAnotherUse();
+  givenIHaveEnteredMyAviationUse(Purpose.COMMERCIAL);
 };
 
-const iCanSeeMyTwoUses = () => {
+const iCanSeeMyThreeUses = () => {
   iCanSeeMyLandUse();
   iCanSeeMyMaritimeUse(Purpose.PLEASURE);
+  iCanSeeMyAviationUse(Purpose.COMMERCIAL);
 };
 
-const iCannotSeeMySecondUseBecauseItIsDeleted = () => {
-  cy.get("main")
+const iCannotSeeWhatWasMySecondUseBecauseItIsDeleted = () =>
+  cy
+    .get("main")
     .contains(/maritime/i && /motor/i && /pleasure/i)
     .should("not.exist");
-};
 
-const andIGoToDeleteMyMainUse = () => {
-  cy.get("h2")
+const andIGoToDeleteMyMainUse = () =>
+  cy
+    .get("h2")
     .contains(/main use/i)
     .siblings()
     .contains(/delete/i)
     .click();
-};
 
-const andIGoToDeleteMySecondUse = () => {
-  cy.get("h2")
+const andIGoToDeleteMySecondUse = () =>
+  cy
+    .get("h2")
     .contains(/second use/i)
     .siblings()
     .contains(/delete/i)
     .click();
-};
 
-const iAmPromptedToConfirmDeletionOfMyMainUse = () => {
+const iAmPromptedToConfirmDeletionOfMyMainUse = () =>
   cy.get("h1").contains(/are you sure/i && /land/i && /cycling/i);
-};
 
-const iAmPromptedToConfirmDeletionOfMySecondUse = () => {
-  cy.get("h1").contains(
-    /are you sure/i && /maritime/i && /motor/i && /pleasure/i
-  );
-};
+const iAmPromptedToConfirmDeletionOfMySecondUse = () =>
+  cy
+    .get("h1")
+    .contains(/are you sure/i && /maritime/i && /motor/i && /pleasure/i);
+
+const iAmEditingWhatIsNowMySecondUse = iCanEditMyAdditionalLandUseMoreDetails;

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -28,7 +28,7 @@ describe("As a beacon owner with several uses", () => {
   });
 });
 
-const iCanSeeMyMainUse = () => iCanSeeMyMaritimeUse(Purpose.PLEASURE);
+const iCanSeeMyMainUse = () => iCanSeeMyLandUse();
 
 const givenIHaveTwoUses = () => {
   givenIHaveEnteredMyBeaconDetails();

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -15,22 +15,23 @@ import {
   iCanSeeMyMaritimeUse,
 } from "../common/i-can-enter-use-information/maritime.spec";
 import {
-  givenIHaveClickedTheButtonContaining,
   whenIClickBack,
+  whenIClickTheButtonContaining,
 } from "../common/selectors-and-assertions.spec";
 
 describe("As a beacon owner with several uses", () => {
   it("I can safely remove a use from my draft registration", () => {
     givenIHaveThreeUses();
-    andIGoToDeleteMyMainUse();
-    iAmPromptedToConfirmDeletionOfMyMainUse();
+    whenIGoToDeleteMyMainUse();
+    thenIAmPromptedToConfirmDeletionOfMyMainUse();
 
-    givenIHaveClickedTheButtonContaining("Cancel");
+    whenIClickTheButtonContaining("Cancel");
     iCanSeeMyThreeUses();
-    andIGoToDeleteMySecondUse();
+
+    whenIGoToDeleteMySecondUse();
     iAmPromptedToConfirmDeletionOfMySecondUse();
 
-    givenIHaveClickedTheButtonContaining("Yes");
+    whenIClickTheButtonContaining("Yes");
     iCanSeeMyMainUse();
     iCannotSeeWhatWasMySecondUseBecauseItIsDeleted();
     myThirdUseIsNowMySecondUse();
@@ -66,7 +67,7 @@ const iCannotSeeWhatWasMySecondUseBecauseItIsDeleted = () =>
     .contains(/maritime/i && /motor/i && /pleasure/i)
     .should("not.exist");
 
-const andIGoToDeleteMyMainUse = () =>
+const whenIGoToDeleteMyMainUse = () =>
   cy
     .get("h2")
     .contains(/main use/i)
@@ -74,7 +75,7 @@ const andIGoToDeleteMyMainUse = () =>
     .contains(/delete/i)
     .click();
 
-const andIGoToDeleteMySecondUse = () =>
+const whenIGoToDeleteMySecondUse = () =>
   cy
     .get("h2")
     .contains(/second use/i)
@@ -82,7 +83,7 @@ const andIGoToDeleteMySecondUse = () =>
     .contains(/delete/i)
     .click();
 
-const iAmPromptedToConfirmDeletionOfMyMainUse = () =>
+const thenIAmPromptedToConfirmDeletionOfMyMainUse = () =>
   cy.get("h1").contains(/are you sure/i && /land/i && /cycling/i);
 
 const iAmPromptedToConfirmDeletionOfMySecondUse = () =>

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -15,17 +15,20 @@ describe("As a beacon owner with several uses", () => {
   it("I can safely remove a use from my draft registration", () => {
     givenIHaveTwoUses();
     andIGoToDeleteMyMainUse();
-    iAmPromptedToConfirmDeletion();
+    iAmPromptedToConfirmDeletionOfMyMainUse();
 
     givenIHaveClickedTheButtonContaining("Cancel");
     iCanSeeMyTwoUses();
     andIGoToDeleteMySecondUse();
-    // TODO: iAmPromptedToConfirmDeletion();
-    // TODO: givenIHaveClickedTheButtonContaining("Yes");
-    // TODO: iCanConfirmMyDeletionChoice;
-    // TODO: iCanSeeMyUsesWithoutTheDeletedUse
+    iAmPromptedToConfirmDeletionOfMySecondUse();
+
+    givenIHaveClickedTheButtonContaining("Yes");
+    iCanSeeMyMainUse();
+    iCannotSeeMySecondUseBecauseItIsDeleted();
   });
 });
+
+const iCanSeeMyMainUse = () => iCanSeeMyMaritimeUse(Purpose.PLEASURE);
 
 const givenIHaveTwoUses = () => {
   givenIHaveEnteredMyBeaconDetails();
@@ -37,6 +40,12 @@ const givenIHaveTwoUses = () => {
 const iCanSeeMyTwoUses = () => {
   iCanSeeMyLandUse();
   iCanSeeMyMaritimeUse(Purpose.PLEASURE);
+};
+
+const iCannotSeeMySecondUseBecauseItIsDeleted = () => {
+  cy.get("main")
+    .contains(/maritime/i && /motor/i && /pleasure/i)
+    .should("not.exist");
 };
 
 const andIGoToDeleteMyMainUse = () => {
@@ -55,6 +64,12 @@ const andIGoToDeleteMySecondUse = () => {
     .click();
 };
 
-const iAmPromptedToConfirmDeletion = () => {
+const iAmPromptedToConfirmDeletionOfMyMainUse = () => {
   cy.get("h1").contains(/are you sure/i && /land/i && /cycling/i);
+};
+
+const iAmPromptedToConfirmDeletionOfMySecondUse = () => {
+  cy.get("h1").contains(
+    /are you sure/i && /maritime/i && /motor/i && /pleasure/i
+  );
 };

--- a/src/gateways/CachedRegistrationGateway.ts
+++ b/src/gateways/CachedRegistrationGateway.ts
@@ -1,0 +1,3 @@
+export interface CachedRegistrationGateway {
+  deleteUse: (submissionId, useIndex) => Promise<void>;
+}

--- a/src/gateways/RedisCachedRegistrationGateway.ts
+++ b/src/gateways/RedisCachedRegistrationGateway.ts
@@ -16,12 +16,16 @@ export class RedisCachedRegistrationGateway
       await cache.get(submissionId)
     ).getRegistration();
 
-    console.log(registration);
+    // console.log("sId: " + submissionId);
+    //
+    // console.log("1: " + registration.uses);
 
     const registrationMinusDeletedUse = {
       ...registration,
       uses: registration.uses.filter((use, i) => i !== useIndex),
     };
+
+    // console.log("2: " + registrationMinusDeletedUse.uses);
 
     await cache.set(
       submissionId,

--- a/src/gateways/RedisCachedRegistrationGateway.ts
+++ b/src/gateways/RedisCachedRegistrationGateway.ts
@@ -16,16 +16,10 @@ export class RedisCachedRegistrationGateway
       await cache.get(submissionId)
     ).getRegistration();
 
-    // console.log("sId: " + submissionId);
-    //
-    // console.log("1: " + registration.uses);
-
     const registrationMinusDeletedUse = {
       ...registration,
       uses: registration.uses.filter((use, i) => i !== useIndex),
     };
-
-    // console.log("2: " + registrationMinusDeletedUse.uses);
 
     await cache.set(
       submissionId,

--- a/src/gateways/RedisCachedRegistrationGateway.ts
+++ b/src/gateways/RedisCachedRegistrationGateway.ts
@@ -1,0 +1,29 @@
+import { FormCacheFactory } from "../lib/formCache";
+import { Registration } from "../lib/registration/registration";
+import { IRegistration } from "../lib/registration/types";
+import { CachedRegistrationGateway } from "./CachedRegistrationGateway";
+
+export class RedisCachedRegistrationGateway
+  implements CachedRegistrationGateway
+{
+  public async deleteUse(
+    submissionId: string,
+    useIndex: number
+  ): Promise<void> {
+    const cache = FormCacheFactory.getCache();
+
+    const registration: IRegistration = (
+      await cache.get(submissionId)
+    ).getRegistration();
+
+    const registrationMinusDeletedUse = {
+      ...registration,
+      uses: registration.uses.filter((use, i) => i !== useIndex),
+    };
+
+    await cache.set(
+      submissionId,
+      new Registration(registrationMinusDeletedUse)
+    );
+  }
+}

--- a/src/gateways/RedisCachedRegistrationGateway.ts
+++ b/src/gateways/RedisCachedRegistrationGateway.ts
@@ -16,6 +16,8 @@ export class RedisCachedRegistrationGateway
       await cache.get(submissionId)
     ).getRegistration();
 
+    console.log(registration);
+
     const registrationMinusDeletedUse = {
       ...registration,
       uses: registration.uses.filter((use, i) => i !== useIndex),

--- a/src/lib/appContainer.ts
+++ b/src/lib/appContainer.ts
@@ -28,7 +28,10 @@ import {
   clearCachedRegistration,
   ClearCachedRegistrationFn,
 } from "../useCases/clearCachedRegistration";
-import { DeleteCachedUseFn } from "../useCases/deleteCachedUse";
+import {
+  deleteCachedUse,
+  DeleteCachedUseFn,
+} from "../useCases/deleteCachedUse";
 import { getAccessToken, GetAccessTokenFn } from "../useCases/getAccessToken";
 import {
   getBeaconsByAccountHolderId,
@@ -91,6 +94,7 @@ export const getAppContainer = (overrides?: IAppContainer): IAppContainer => {
     getCachedRegistration: getCachedRegistration,
     saveCachedRegistration: saveCachedRegistration,
     clearCachedRegistration: clearCachedRegistration,
+    deleteCachedUse: deleteCachedUse,
     getSession: getSession,
 
     /* Composite use cases requiring access to other use cases */

--- a/src/lib/appContainer.ts
+++ b/src/lib/appContainer.ts
@@ -28,6 +28,7 @@ import {
   clearCachedRegistration,
   ClearCachedRegistrationFn,
 } from "../useCases/clearCachedRegistration";
+import { DeleteCachedUseFn } from "../useCases/deleteCachedUse";
 import { getAccessToken, GetAccessTokenFn } from "../useCases/getAccessToken";
 import {
   getBeaconsByAccountHolderId,
@@ -67,6 +68,7 @@ export interface IAppContainer {
   getCachedRegistration: GetCachedRegistrationFn;
   saveCachedRegistration: SaveCachedRegistrationFn;
   clearCachedRegistration: ClearCachedRegistrationFn;
+  deleteCachedUse: DeleteCachedUseFn;
   getAccessToken: GetAccessTokenFn;
   getSession: GetSessionFn;
   getOrCreateAccountHolder: GetOrCreateAccountHolderFn;

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1,8 +1,14 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  NextApiHandler,
+  NextApiRequest,
+  NextApiResponse,
+} from "next";
 import { appContainer, IAppContainer } from "./appContainer";
 
 export type BeaconsGetServerSidePropsContext = GetServerSidePropsContext & {
-  container: IAppContainer;
+  container: Partial<IAppContainer>;
 };
 
 export const withContainer =
@@ -10,4 +16,15 @@ export const withContainer =
   (context: BeaconsGetServerSidePropsContext) => {
     context.container = context.container || appContainer;
     return callback(context);
+  };
+
+export type BeaconsApiRequest = NextApiRequest & {
+  container: Partial<IAppContainer>;
+};
+
+export const withApiContainer =
+  (callback: NextApiHandler): NextApiHandler =>
+  (req: BeaconsApiRequest, res: NextApiResponse) => {
+    req.container = req.container || appContainer;
+    return callback(req, res);
   };

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -8,7 +8,7 @@ import {
 import { appContainer, IAppContainer } from "./appContainer";
 
 export type BeaconsGetServerSidePropsContext = GetServerSidePropsContext & {
-  container: Partial<IAppContainer>;
+  container: IAppContainer;
 };
 
 export const withContainer =

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -48,5 +48,5 @@ export function formatUrlQueryParams(
     formatUrl(queryParam, value);
   });
 
-  return url;
+  return encodeURI(url);
 }

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -25,10 +25,11 @@ export enum PageURLs {
   emergencyContact = "/register-a-beacon/emergency-contact",
   checkYourAnswers = "/register-a-beacon/check-your-answers",
   applicationComplete = "/register-a-beacon/application-complete",
+  serverError = "/500",
 }
 
 export enum ActionURLs {
-  deleteCachedUse = "/todo",
+  deleteCachedUse = "/api/registration/delete-use",
 }
 
 export function formatUrlQueryParams(

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -48,5 +48,8 @@ export function formatUrlQueryParams(
     formatUrl(queryParam, value);
   });
 
-  return encodeURI(url);
+  return url;
 }
+
+export const queryParams = (queryParams: Record<string, any>): string =>
+  "?" + new URLSearchParams(queryParams).toString();

--- a/src/pages/api/registration/delete-use.ts
+++ b/src/pages/api/registration/delete-use.ts
@@ -9,9 +9,9 @@ export const handler = withApiContainer(async (req: BeaconsApiRequest, res) => {
 
   try {
     await deleteCachedUse(submissionId, parseInt(useIndex));
-    res.redirect(303, onSuccess);
+    res.redirect(onSuccess);
   } catch (e) {
-    res.redirect(303, onFailure);
+    res.redirect(onFailure);
   }
 });
 

--- a/src/pages/api/registration/delete-use.ts
+++ b/src/pages/api/registration/delete-use.ts
@@ -4,8 +4,17 @@ import { BeaconsApiRequest, withApiContainer } from "../../../lib/container";
 const handler: NextApiHandler = withApiContainer(
   async (req: BeaconsApiRequest, res: NextApiResponse) => {
     const { deleteCachedUse } = req.container;
+    const { useIndex, onSuccess, onFailure } = req.query as {
+      [key: string]: string;
+    };
 
-    await deleteCachedUse("test-submission-id", 0);
+    try {
+      await deleteCachedUse("test-submission-id", parseInt(useIndex));
+    } catch (e) {
+      res.redirect(onFailure);
+    }
+
+    res.redirect(onSuccess);
   }
 );
 

--- a/src/pages/api/registration/delete-use.ts
+++ b/src/pages/api/registration/delete-use.ts
@@ -1,0 +1,12 @@
+import { NextApiHandler, NextApiResponse } from "next";
+import { BeaconsApiRequest, withApiContainer } from "../../../lib/container";
+
+const handler: NextApiHandler = withApiContainer(
+  async (req: BeaconsApiRequest, res: NextApiResponse) => {
+    const { deleteCachedUse } = req.container;
+
+    await deleteCachedUse("test-submission-id", 0);
+  }
+);
+
+export default handler;

--- a/src/pages/api/registration/delete-use.ts
+++ b/src/pages/api/registration/delete-use.ts
@@ -2,12 +2,13 @@ import { BeaconsApiRequest, withApiContainer } from "../../../lib/container";
 
 export const handler = withApiContainer(async (req: BeaconsApiRequest, res) => {
   const { deleteCachedUse } = req.container;
+  const { submissionId } = req.cookies;
   const { useIndex, onSuccess, onFailure } = req.query as {
     [key: string]: string;
   };
 
   try {
-    await deleteCachedUse("test-submission-id", parseInt(useIndex));
+    await deleteCachedUse(submissionId, parseInt(useIndex));
     res.redirect(303, onSuccess);
   } catch (e) {
     res.redirect(303, onFailure);

--- a/src/pages/api/registration/delete-use.ts
+++ b/src/pages/api/registration/delete-use.ts
@@ -1,21 +1,17 @@
-import { NextApiHandler, NextApiResponse } from "next";
 import { BeaconsApiRequest, withApiContainer } from "../../../lib/container";
 
-const handler: NextApiHandler = withApiContainer(
-  async (req: BeaconsApiRequest, res: NextApiResponse) => {
-    const { deleteCachedUse } = req.container;
-    const { useIndex, onSuccess, onFailure } = req.query as {
-      [key: string]: string;
-    };
+export const handler = withApiContainer(async (req: BeaconsApiRequest, res) => {
+  const { deleteCachedUse } = req.container;
+  const { useIndex, onSuccess, onFailure } = req.query as {
+    [key: string]: string;
+  };
 
-    try {
-      await deleteCachedUse("test-submission-id", parseInt(useIndex));
-    } catch (e) {
-      res.redirect(onFailure);
-    }
-
-    res.redirect(onSuccess);
+  try {
+    await deleteCachedUse("test-submission-id", parseInt(useIndex));
+    res.redirect(303, onSuccess);
+  } catch (e) {
+    res.redirect(303, onFailure);
   }
-);
+});
 
 export default handler;

--- a/src/pages/are-you-sure.tsx
+++ b/src/pages/are-you-sure.tsx
@@ -52,7 +52,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const props: AreYouSureProps = {
     actionText: action as string,
-    consequencesText: consequences as string,
+    consequencesText: (consequences as string) || null,
     redirectUriIfYes: yes as string,
     redirectUriIfCancel: no as string,
   };

--- a/src/pages/are-you-sure.tsx
+++ b/src/pages/are-you-sure.tsx
@@ -47,23 +47,6 @@ export const AreYouSure: FunctionComponent<AreYouSureProps> = ({
   );
 };
 
-export const buildAreYouSureQuery = (
-  action: string,
-  yes: string,
-  no: string,
-  consequences: string
-): string => {
-  return (
-    "?" +
-    new URLSearchParams({
-      action,
-      yes,
-      no,
-      consequences,
-    }).toString()
-  );
-};
-
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { action, consequences, yes, no } = context.query;
 

--- a/src/pages/are-you-sure.tsx
+++ b/src/pages/are-you-sure.tsx
@@ -35,10 +35,8 @@ export const AreYouSure: FunctionComponent<AreYouSureProps> = ({
             <LinkButton
               buttonText="Cancel"
               href={redirectUriIfCancel}
-              classes="govuk-button--secondary"
+              classes="govuk-button--secondary govuk-!-margin-right-8"
             />
-            <br />
-            <br />
             <LinkButton buttonText="Yes" href={redirectUriIfYes} />
           </>
         }

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -19,7 +19,7 @@ import { buildAreYouSureQuery } from "../are-you-sure";
 
 interface AdditionalBeaconUseProps {
   uses: BeaconUse[];
-  currentUseIndex?: number;
+  currentUseIndex: number;
   showCookieBanner?: boolean;
 }
 
@@ -116,7 +116,8 @@ const confirmBeforeDelete = (use, index) => {
     ActionURLs.deleteCachedUse +
     buildDeleteUseQuery(
       index,
-      PageURLs.additionalUse + buildAdditionalBeaconUseQuery(index - 1),
+      PageURLs.additionalUse +
+        buildAdditionalBeaconUseQuery(index >= 1 ? index - 1 : 0),
       PageURLs.serverError
     );
   const no = PageURLs.additionalUse + "?useIndex=" + index;
@@ -139,7 +140,8 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
 
     if (currentUseIndexDoesNotExist(context, registration))
       throw new ReferenceError(
-        "Page was accessed with a useIndex parameter that does not exist on the cached registration."
+        PageURLs.additionalUse +
+          " was accessed with a useIndex parameter that does not exist on the cached registration."
       );
 
     return {

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -62,23 +62,12 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
               {uses.length > 0 && (
                 <>
                   {uses.map((use, index) => {
-                    // Prompt the user to confirm before deleting their use
-                    const action = "delete your " + prettyUseName(use) + " use";
-                    const consequences =
-                      "You will have the opportunity to review this change at the end.";
-                    const yes =
-                      ActionURLs.deleteCachedUse + "?useIndex=" + index;
-                    const no = PageURLs.additionalUse + "?useIndex=" + index;
-                    const deleteUri =
-                      PageURLs.areYouSure +
-                      buildAreYouSureQuery(action, yes, no, consequences);
-
                     return (
                       <BeaconUseSection
                         index={index}
                         use={use}
                         changeUri={PageURLs.environment + "?useIndex=" + index}
-                        deleteUri={deleteUri}
+                        deleteUri={confirmBeforeDelete(use, index)}
                         key={`row${index}`}
                       />
                     );
@@ -101,6 +90,18 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
         />
       </Layout>
     </>
+  );
+};
+
+const confirmBeforeDelete = (use, index) => {
+  const action = "delete your " + prettyUseName(use) + " use";
+  const yes = ActionURLs.deleteCachedUse + "?useIndex=" + index;
+  const no = PageURLs.additionalUse + "?useIndex=" + index;
+  const consequences =
+    "You will have the opportunity to review this change at the end.";
+
+  return (
+    PageURLs.areYouSure + buildAreYouSureQuery(action, yes, no, consequences)
   );
 };
 

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -15,7 +15,6 @@ import { BeaconUse, IRegistration } from "../../lib/registration/types";
 import { retrieveUserFormSubmissionId } from "../../lib/retrieveUserFormSubmissionId";
 import { ActionURLs, formatUrlQueryParams, PageURLs } from "../../lib/urls";
 import { prettyUseName } from "../../lib/writingStyle";
-import { buildAreYouSureQuery } from "../are-you-sure";
 
 interface AdditionalBeaconUseProps {
   uses: BeaconUse[];
@@ -95,39 +94,20 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
   );
 };
 
-const buildDeleteUseQuery = (
-  useIndex: number,
-  onSuccess: string,
-  onFailure: string
-): string =>
-  "?" +
-  new URLSearchParams({
-    useIndex: useIndex.toString(),
-    onSuccess,
-    onFailure,
-  }).toString();
-
-export const buildAdditionalBeaconUseQuery = (useIndex: number): string =>
-  "?" + new URLSearchParams({ useIndex: useIndex.toString() }).toString();
-
-const confirmBeforeDelete = (use, index) => {
-  const action = "delete your " + prettyUseName(use) + " use";
-  const yes =
-    ActionURLs.deleteCachedUse +
-    buildDeleteUseQuery(
-      index,
-      PageURLs.additionalUse +
-        buildAdditionalBeaconUseQuery(index >= 1 ? index - 1 : 0),
-      PageURLs.serverError
-    );
-  const no = PageURLs.additionalUse + "?useIndex=" + index;
-  const consequences =
-    "You will have the opportunity to review this change at the end.";
-
-  return (
-    PageURLs.areYouSure + buildAreYouSureQuery(action, yes, no, consequences)
-  );
-};
+const confirmBeforeDelete = (use, index) =>
+  formatUrlQueryParams(PageURLs.areYouSure, {
+    action: "delete your " + prettyUseName(use) + " use",
+    yes: formatUrlQueryParams(ActionURLs.deleteCachedUse, {
+      useIndex: index,
+      onSuccess: formatUrlQueryParams(PageURLs.additionalUse, {
+        useIndex: index >= 1 ? index - 1 : 0,
+      }),
+      onFailure: PageURLs.serverError,
+    }),
+    no: formatUrlQueryParams(PageURLs.additionalUse, { useIndex: index }),
+    consequences:
+      "You will have the opportunity to review this change at the end.",
+  });
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -115,8 +115,6 @@ const confirmBeforeDelete = (use, index) =>
         onFailure: PageURLs.serverError,
       }),
     no: PageURLs.additionalUse + queryParams({ useIndex: index }),
-    consequences:
-      "You will have the opportunity to review this change at the end.",
   });
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -126,7 +126,10 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
       await getCachedRegistration(submissionId)
     ).getRegistration();
 
-    if (currentUseIndexDoesNotExist(context, registration))
+    if (
+      registration.uses.length >= 1 &&
+      currentUseIndexDoesNotExist(context, registration)
+    )
       throw new ReferenceError(
         PageURLs.additionalUse +
           " was accessed with a useIndex parameter that does not exist on the cached registration."

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -13,7 +13,7 @@ import { showCookieBanner } from "../../lib/cookies";
 import { withCookieRedirect } from "../../lib/middleware";
 import { BeaconUse, IRegistration } from "../../lib/registration/types";
 import { retrieveUserFormSubmissionId } from "../../lib/retrieveUserFormSubmissionId";
-import { ActionURLs, formatUrlQueryParams, PageURLs } from "../../lib/urls";
+import { ActionURLs, PageURLs, queryParams } from "../../lib/urls";
 import { prettyUseName } from "../../lib/writingStyle";
 
 interface AdditionalBeaconUseProps {
@@ -34,9 +34,12 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
       <Layout
         navigation={
           <BackButton
-            href={formatUrlQueryParams(PageURLs.moreDetails, {
-              useIndex: currentUseIndex || uses.length - 1,
-            })}
+            href={
+              PageURLs.moreDetails +
+              queryParams({
+                useIndex: currentUseIndex || uses.length - 1,
+              })
+            }
           />
         }
         title={pageHeading}
@@ -95,16 +98,21 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
 };
 
 const confirmBeforeDelete = (use, index) =>
-  formatUrlQueryParams(PageURLs.areYouSure, {
+  PageURLs.areYouSure +
+  queryParams({
     action: "delete your " + prettyUseName(use) + " use",
-    yes: formatUrlQueryParams(ActionURLs.deleteCachedUse, {
-      useIndex: index,
-      onSuccess: formatUrlQueryParams(PageURLs.additionalUse, {
-        useIndex: index >= 1 ? index - 1 : 0,
+    yes:
+      ActionURLs.deleteCachedUse +
+      queryParams({
+        useIndex: index,
+        onSuccess:
+          PageURLs.additionalUse +
+          queryParams({
+            useIndex: index >= 1 ? index - 1 : 0,
+          }),
+        onFailure: PageURLs.serverError,
       }),
-      onFailure: PageURLs.serverError,
-    }),
-    no: formatUrlQueryParams(PageURLs.additionalUse, { useIndex: index }),
+    no: PageURLs.additionalUse + queryParams({ useIndex: index }),
     consequences:
       "You will have the opportunity to review this change at the end.",
   });

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -93,9 +93,30 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
   );
 };
 
+const buildDeleteUseQuery = (
+  useIndex: number,
+  onSuccess: string,
+  onFailure: string
+): string =>
+  "?" +
+  new URLSearchParams({
+    useIndex: useIndex.toString(),
+    onSuccess,
+    onFailure,
+  }).toString();
+
+export const buildAdditionalBeaconUseQuery = (useIndex: number) =>
+  "?" + new URLSearchParams({ useIndex: useIndex.toString() }).toString();
+
 const confirmBeforeDelete = (use, index) => {
   const action = "delete your " + prettyUseName(use) + " use";
-  const yes = ActionURLs.deleteCachedUse + "?useIndex=" + index;
+  const yes =
+    ActionURLs.deleteCachedUse +
+    buildDeleteUseQuery(
+      index,
+      PageURLs.additionalUse + buildAdditionalBeaconUseQuery(index - 1),
+      PageURLs.serverError
+    );
   const no = PageURLs.additionalUse + "?useIndex=" + index;
   const consequences =
     "You will have the opportunity to review this change at the end.";

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -33,14 +33,16 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
     <>
       <Layout
         navigation={
-          <BackButton
-            href={
-              PageURLs.moreDetails +
-              queryParams({
-                useIndex: currentUseIndex || uses.length - 1,
-              })
-            }
-          />
+          uses.length > 0 && (
+            <BackButton
+              href={
+                PageURLs.moreDetails +
+                queryParams({
+                  useIndex: currentUseIndex || uses.length - 1,
+                })
+              }
+            />
+          )
         }
         title={pageHeading}
         showCookieBanner={showCookieBanner}

--- a/src/useCases/deleteCachedUse.ts
+++ b/src/useCases/deleteCachedUse.ts
@@ -4,7 +4,7 @@ import { RedisCachedRegistrationGateway } from "../gateways/RedisCachedRegistrat
 export type DeleteCachedUseFn = (
   submissionId: string,
   useIndex: number,
-  cachedRegistrationGateway: CachedRegistrationGateway
+  cachedRegistrationGateway?: CachedRegistrationGateway
 ) => Promise<void>;
 
 export const deleteCachedUse: DeleteCachedUseFn = async (

--- a/src/useCases/deleteCachedUse.ts
+++ b/src/useCases/deleteCachedUse.ts
@@ -1,4 +1,15 @@
+import { CachedRegistrationGateway } from "../gateways/CachedRegistrationGateway";
+
 export type DeleteCachedUseFn = (
   submissionId: string,
-  useIndex: number
+  useIndex: number,
+  cachedRegistrationGateway: CachedRegistrationGateway
 ) => Promise<void>;
+
+export const deleteCachedUse: DeleteCachedUseFn = async (
+  submissionId,
+  useIndex,
+  cachedRegistrationGateway
+) => {
+  await cachedRegistrationGateway.deleteUse(submissionId, useIndex);
+};

--- a/src/useCases/deleteCachedUse.ts
+++ b/src/useCases/deleteCachedUse.ts
@@ -1,4 +1,5 @@
 import { CachedRegistrationGateway } from "../gateways/CachedRegistrationGateway";
+import { RedisCachedRegistrationGateway } from "../gateways/RedisCachedRegistrationGateway";
 
 export type DeleteCachedUseFn = (
   submissionId: string,
@@ -9,7 +10,7 @@ export type DeleteCachedUseFn = (
 export const deleteCachedUse: DeleteCachedUseFn = async (
   submissionId,
   useIndex,
-  cachedRegistrationGateway
+  cachedRegistrationGateway = new RedisCachedRegistrationGateway()
 ) => {
   await cachedRegistrationGateway.deleteUse(submissionId, useIndex);
 };

--- a/src/useCases/deleteCachedUse.ts
+++ b/src/useCases/deleteCachedUse.ts
@@ -1,0 +1,4 @@
+export type DeleteCachedUseFn = (
+  submissionId: string,
+  useIndex: number
+) => Promise<void>;

--- a/test/lib/urls.test.ts
+++ b/test/lib/urls.test.ts
@@ -1,0 +1,49 @@
+import { formatUrlQueryParams } from "../../src/lib/urls";
+
+describe("format URL query params function", () => {
+  let url;
+  let queryParamMap;
+
+  beforeEach(() => {
+    url = "/beacons";
+    queryParamMap = { useIndex: 0 };
+  });
+
+  it("should add a query param if none is specified", () => {
+    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
+      "/beacons?useIndex=0"
+    );
+  });
+
+  it("should add an ampersand if a query param is already specified", () => {
+    url += "?beaconIndex=0";
+    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
+      "/beacons?beaconIndex=0&useIndex=0"
+    );
+  });
+
+  it("should correctly combine multiple query params", () => {
+    queryParamMap = { useIndex: 0, beaconIndex: 0, hexId: "hello" };
+    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
+      "/beacons?useIndex=0&beaconIndex=0&hexId=hello"
+    );
+  });
+
+  it("should not overwrite query params already in the url", () => {
+    url += "?useIndex=0";
+    queryParamMap = { useIndex: 0, beaconIndex: 0 };
+    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
+      "/beacons?useIndex=0&beaconIndex=0"
+    );
+  });
+
+  it("should URL-encode strings", () => {
+    url += "?useIndex=0";
+    queryParamMap = {
+      action: "here are some chars that should be URL-encoded",
+    };
+    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
+      "/beacons?useIndex=0&action=here%20are%20some%20chars%20that%20should%20be%20URL-encoded"
+    );
+  });
+});

--- a/test/lib/urls.test.ts
+++ b/test/lib/urls.test.ts
@@ -36,14 +36,4 @@ describe("format URL query params function", () => {
       "/beacons?useIndex=0&beaconIndex=0"
     );
   });
-
-  it("should URL-encode strings", () => {
-    url += "?useIndex=0";
-    queryParamMap = {
-      action: "here are some chars that should be URL-encoded",
-    };
-    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
-      "/beacons?useIndex=0&action=here%20are%20some%20chars%20that%20should%20be%20URL-encoded"
-    );
-  });
 });

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,4 +1,3 @@
-import { formatUrlQueryParams } from "../../src/lib/urls";
 import { toArray } from "../../src/lib/utils";
 import {
   makeEnumValueUserFriendly,
@@ -104,44 +103,6 @@ describe("pad number with leading zeros function", () => {
 
   it("should not pad a word", () => {
     expect(padNumberWithLeadingZeros("beacon")).toBe("beacon");
-  });
-});
-
-describe("format URL query params function", () => {
-  let url;
-  let queryParamMap;
-
-  beforeEach(() => {
-    url = "/beacons";
-    queryParamMap = { useIndex: 0 };
-  });
-
-  it("should add a query param if none is specified", () => {
-    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
-      "/beacons?useIndex=0"
-    );
-  });
-
-  it("should add an ampersand if a query param is already specified", () => {
-    url += "?beaconIndex=0";
-    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
-      "/beacons?beaconIndex=0&useIndex=0"
-    );
-  });
-
-  it("should correctly combine multiple query params", () => {
-    queryParamMap = { useIndex: 0, beaconIndex: 0, hexId: "hello" };
-    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
-      "/beacons?useIndex=0&beaconIndex=0&hexId=hello"
-    );
-  });
-
-  it("should not overwrite query params already in the url", () => {
-    url += "?useIndex=0";
-    queryParamMap = { useIndex: 0, beaconIndex: 0 };
-    expect(formatUrlQueryParams(url, queryParamMap)).toBe(
-      "/beacons?useIndex=0&beaconIndex=0"
-    );
   });
 });
 

--- a/test/pages/api/registration/delete-use.test.ts
+++ b/test/pages/api/registration/delete-use.test.ts
@@ -4,8 +4,55 @@ import { formSubmissionCookieId } from "../../../../src/lib/types";
 import handler from "../../../../src/pages/api/registration/delete-use";
 
 describe("/api/registration/delete-use", () => {
-  it("calls the injected deleteCachedUse use case", () => {
-    const useIndex = 0;
+  it("calls the injected deleteCachedUse use case to delete a use by index", async () => {
+    const req: Partial<BeaconsApiRequest> = {
+      cookies: {
+        [formSubmissionCookieId]: "test-submission-id",
+      },
+      query: {
+        useIndex: "0",
+        onSuccess: "/irrelevant-on-success-path",
+        onFailure: "/irrelevant-on-failure-path",
+      },
+      container: {
+        deleteCachedUse: jest.fn(),
+      },
+    };
+    const res: Partial<NextApiResponse> = { redirect: jest.fn() };
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(req.container.deleteCachedUse).toHaveBeenCalledWith(
+      req.cookies[formSubmissionCookieId],
+      0
+    );
+  });
+
+  it("does the same for other values of useIndex", async () => {
+    const req: Partial<BeaconsApiRequest> = {
+      cookies: {
+        [formSubmissionCookieId]: "test-submission-id",
+      },
+      query: {
+        useIndex: "12",
+        onSuccess: "/irrelevant-on-success-path",
+        onFailure: "/irrelevant-on-failure-path",
+      },
+      container: {
+        deleteCachedUse: jest.fn(),
+      },
+    };
+    const res: Partial<NextApiResponse> = { redirect: jest.fn() };
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(req.container.deleteCachedUse).toHaveBeenCalledWith(
+      req.cookies[formSubmissionCookieId],
+      12
+    );
+  });
+
+  it("redirects the user to the onSuccess URI when deleting is successful", async () => {
     const submissionId = "test-submission-id";
     const deleteCachedUse = jest.fn();
     const req: Partial<BeaconsApiRequest> = {
@@ -13,17 +60,42 @@ describe("/api/registration/delete-use", () => {
         [formSubmissionCookieId]: submissionId,
       },
       query: {
-        onSuccess: "/irrelevant-on-success-path",
+        useIndex: "0",
+        onSuccess: "/on-success-path",
         onFailure: "/irrelevant-on-failure-path",
       },
       container: {
         deleteCachedUse: deleteCachedUse,
       },
     };
-    const res: Partial<NextApiResponse> = {};
+    const res: Partial<NextApiResponse> = { redirect: jest.fn() };
 
-    handler(req as NextApiRequest, res as NextApiResponse);
+    await handler(req as NextApiRequest, res as NextApiResponse);
 
-    expect(deleteCachedUse).toHaveBeenCalledWith(submissionId, useIndex);
+    expect(res.redirect).toHaveBeenCalledWith(req.query.onSuccess);
+  });
+
+  it("redirects the user to the onFailure URI when deleting is not successful", async () => {
+    const submissionId = "test-submission-id";
+    const req: Partial<BeaconsApiRequest> = {
+      cookies: {
+        [formSubmissionCookieId]: submissionId,
+      },
+      query: {
+        useIndex: "0",
+        onSuccess: "/on-success-path",
+        onFailure: "/irrelevant-on-failure-path",
+      },
+      container: {
+        deleteCachedUse: jest.fn().mockImplementation(() => {
+          throw new Error();
+        }),
+      },
+    };
+    const res: Partial<NextApiResponse> = { redirect: jest.fn() };
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(res.redirect).toHaveBeenCalledWith(req.query.onFailure);
   });
 });

--- a/test/pages/api/registration/delete-use.test.ts
+++ b/test/pages/api/registration/delete-use.test.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { BeaconsApiRequest } from "../../../../src/lib/container";
+import { formSubmissionCookieId } from "../../../../src/lib/types";
+import handler from "../../../../src/pages/api/registration/delete-use";
+
+describe("/api/registration/delete-use", () => {
+  it("calls the injected deleteCachedUse use case", () => {
+    const useIndex = 0;
+    const submissionId = "test-submission-id";
+    const deleteCachedUse = jest.fn();
+    const req: Partial<BeaconsApiRequest> = {
+      cookies: {
+        [formSubmissionCookieId]: submissionId,
+      },
+      query: {
+        onSuccess: "/irrelevant-on-success-path",
+        onFailure: "/irrelevant-on-failure-path",
+      },
+      container: {
+        deleteCachedUse: deleteCachedUse,
+      },
+    };
+    const res: Partial<NextApiResponse> = {};
+
+    handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(deleteCachedUse).toHaveBeenCalledWith(submissionId, useIndex);
+  });
+});

--- a/test/pages/are-you-sure.test.tsx
+++ b/test/pages/are-you-sure.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import AreYouSure, { buildAreYouSureQuery } from "../../src/pages/are-you-sure";
+import AreYouSure from "../../src/pages/are-you-sure";
 
 describe("AreYouSure", () => {
   it("plays back the action in the header as a question", () => {
@@ -60,20 +60,5 @@ describe("AreYouSure", () => {
     const yesButton = screen.getByRole("button", { name: "Yes" });
     expect(yesButton).toBeVisible();
     expect(yesButton).toHaveAttribute("href", redirectUriIfYes);
-  });
-});
-
-describe("buildAreYouSureQuery", () => {
-  it("builds an AreYouSure query from values", () => {
-    const action = "Delete your use";
-    const yes = "/api/delete-use";
-    const no = "/register-a-beacon/additional-beacon-use";
-    const consequences = "We may not come and rescue you.";
-
-    const result = buildAreYouSureQuery(action, yes, no, consequences);
-
-    expect(result).toEqual(
-      "?action=Delete+your+use&yes=%2Fapi%2Fdelete-use&no=%2Fregister-a-beacon%2Fadditional-beacon-use&consequences=We+may+not+come+and+rescue+you."
-    );
   });
 });

--- a/test/pages/are-you-sure.test.tsx
+++ b/test/pages/are-you-sure.test.tsx
@@ -64,7 +64,7 @@ describe("AreYouSure", () => {
 });
 
 describe("buildAreYouSureQuery", () => {
-  it("builds its an AreYouSure query from values", () => {
+  it("builds an AreYouSure query from values", () => {
     const action = "Delete your use";
     const yes = "/api/delete-use";
     const no = "/register-a-beacon/additional-beacon-use";

--- a/test/pages/register-a-beacon/additional-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/additional-beacon-use.test.tsx
@@ -16,7 +16,9 @@ describe("AdditionalBeaconUse page", () => {
   it("given there are no uses, displays a 'no assigned uses' message", () => {
     render(<AdditionalBeaconUse uses={[]} currentUseIndex={0} />);
 
-    expect(screen.getByText(/have not assigned any uses to this beacon yet/i));
+    expect(
+      screen.getByText(/have not assigned any uses to this beacon yet/i)
+    ).toBeVisible();
   });
 
   it("given there are no uses, doesn't allow the user to continue to the next stage", () => {
@@ -29,6 +31,12 @@ describe("AdditionalBeaconUse page", () => {
     render(<AdditionalBeaconUse uses={[]} currentUseIndex={0} />);
 
     expect(screen.getByRole("button", { name: /add a use/i }));
+  });
+
+  it("given there are no uses, doesn't allow the user to go 'back' to the use-editing path", () => {
+    render(<AdditionalBeaconUse uses={[]} currentUseIndex={0} />);
+
+    expect(screen.queryByRole("link", { name: /back/i })).toBeNull();
   });
 
   it("given there is one use, displays that use", () => {

--- a/test/pages/register-a-beacon/additional-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/additional-beacon-use.test.tsx
@@ -36,7 +36,7 @@ describe("AdditionalBeaconUse page", () => {
   it("given there are no uses, doesn't allow the user to go 'back' to the use-editing path", () => {
     render(<AdditionalBeaconUse uses={[]} currentUseIndex={0} />);
 
-    expect(screen.queryByRole("link", { name: /back/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^back$/i })).toBeNull();
   });
 
   it("given there is one use, displays that use", () => {

--- a/test/pages/register-a-beacon/additional-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/additional-beacon-use.test.tsx
@@ -6,7 +6,7 @@ import {
   Purpose,
 } from "../../../src/lib/registration/types";
 import { formSubmissionCookieId } from "../../../src/lib/types";
-import { formatUrlQueryParams, PageURLs } from "../../../src/lib/urls";
+import { PageURLs, queryParams } from "../../../src/lib/urls";
 import AdditionalBeaconUse, {
   getServerSideProps,
 } from "../../../src/pages/register-a-beacon/additional-beacon-use";
@@ -73,7 +73,7 @@ describe("AdditionalBeaconUse page", () => {
 
     expect(screen.getByRole("link", { name: "Back" })).toHaveAttribute(
       "href",
-      formatUrlQueryParams(PageURLs.moreDetails, { useIndex: currentUseIndex })
+      PageURLs.moreDetails + queryParams({ useIndex: currentUseIndex })
     );
   });
 

--- a/test/useCases/deleteCachedUse.test.ts
+++ b/test/useCases/deleteCachedUse.test.ts
@@ -2,18 +2,32 @@ import { CachedRegistrationGateway } from "../../src/gateways/CachedRegistration
 import { deleteCachedUse } from "../../src/useCases/deleteCachedUse";
 
 describe("deleteCachedUse", () => {
-  it("calls the injected CachedRegistrationGateway to delete the cached use", () => {
+  it("calls the injected CachedRegistrationGateway to delete the cached use", async () => {
     const submissionId = "test-submissionId";
     const useIndex = 0;
     const cachedRegistrationGateway: CachedRegistrationGateway = {
       deleteUse: jest.fn(),
     };
 
-    deleteCachedUse(submissionId, useIndex, cachedRegistrationGateway);
+    await deleteCachedUse(submissionId, useIndex, cachedRegistrationGateway);
 
     expect(cachedRegistrationGateway.deleteUse).toHaveBeenCalledWith(
       submissionId,
       useIndex
     );
+  });
+
+  it("throws if there is an error during deletion", async () => {
+    const submissionId = "test-submissionId";
+    const useIndex = 0;
+    const cachedRegistrationGateway: CachedRegistrationGateway = {
+      deleteUse: jest.fn().mockImplementation(() => {
+        throw new Error();
+      }),
+    };
+
+    await expect(
+      deleteCachedUse(submissionId, useIndex, cachedRegistrationGateway)
+    ).rejects.toThrow();
   });
 });

--- a/test/useCases/deleteCachedUse.test.ts
+++ b/test/useCases/deleteCachedUse.test.ts
@@ -1,0 +1,19 @@
+import { CachedRegistrationGateway } from "../../src/gateways/CachedRegistrationGateway";
+import { deleteCachedUse } from "../../src/useCases/deleteCachedUse";
+
+describe("deleteCachedUse", () => {
+  it("calls the injected CachedRegistrationGateway to delete the cached use", () => {
+    const submissionId = "test-submissionId";
+    const useIndex = 0;
+    const cachedRegistrationGateway: CachedRegistrationGateway = {
+      deleteUse: jest.fn(),
+    };
+
+    deleteCachedUse(submissionId, useIndex, cachedRegistrationGateway);
+
+    expect(cachedRegistrationGateway.deleteUse).toHaveBeenCalledWith(
+      submissionId,
+      useIndex
+    );
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

After a user has been asked "Are you sure you want to delete your Maritime: Rowing (Pleasure) use?", and they click "Yes", there needs to be a way to carry out that action and then serve a new page.

This PR creates a NextJS API endpoint `/api/delete-use` that does just that 💥.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Extend the Cypress tests in `i-can-remove-a-use.spec.ts` to carry out the delete action and assert that the UI updates.
- API endpoint with unit tests.
- A new `deleteCachedUse` use case with unit tests.
- A new `CachedRegistrationGateway` abstraction + `RedisCachedRegistrationGateway` implementation.
- Link it all together with production code.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- Using a NextJS API route with redirects should be a re-usable pattern for whenever we need to `do X then redirect to Y`.  This should help us gradually continue the slaying of `handlePageRequest` 🐉⚔️. Can you see how it could be built on for future use cases?  Is it "discoverable"? 

Also see other inline comments :-) 

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

https://trello.com/c/nuEwKc21

## Things to check

~~- [ ] Environment variables have been updated~~ N/A