### PR TITLE
Fix implicit any in `register-beacon/additional-beacon-use`

### DIFF
--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -32,21 +32,21 @@ import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserS
 import { IfUserViewedRegistrationForm } from "../../router/rules/IfUserViewedRegistrationForm";
 
 interface ActivityForm {
-  environment;
-  activity;
-  otherActivityText;
-  otherActivityLocation;
-  otherActivityPeopleCount;
-  workingRemotelyLocation;
-  workingRemotelyPeopleCount;
-  windfarmLocation;
-  windfarmPeopleCount;
+  environment: string;
+  activity: string;
+  otherActivityText: string;
+  otherActivityLocation: string;
+  otherActivityPeopleCount: string;
+  workingRemotelyLocation: string;
+  workingRemotelyPeopleCount: string;
+  windfarmLocation: string;
+  windfarmPeopleCount: string;
 }
 
 interface ActivityPageProps extends DraftRegistrationPageProps {
-  environment;
-  purpose;
-  useIndex;
+  environment: Environment;
+  purpose: Purpose;
+  useIndex: number;
 }
 
 const ActivityPage: FunctionComponent<ActivityPageProps> = ({
@@ -621,8 +621,8 @@ const props = async (
   ).uses[context.query.useIndex as string];
 
   return {
-    environment: use?.environment || null,
-    purpose: use?.purpose || null,
+    environment: (use?.environment as Environment) || null,
+    purpose: (use?.purpose as Purpose) || null,
     useIndex: parseInt(context.query.useIndex as string),
   };
 };
@@ -633,27 +633,29 @@ const mapper = (
   const beaconUseMapper: BeaconUseFormMapper<ActivityForm> = {
     formToDraftBeaconUse: (form) => {
       return {
-        environment: form.environment,
-        activity: form.activity,
-        otherActivityText: form.otherActivityText,
-        otherActivityLocation: form.otherActivityLocation,
-        otherActivityPeopleCount: form.otherActivityPeopleCount,
-        workingRemotelyLocation: form.workingRemotelyLocation,
-        workingRemotelyPeopleCount: form.workingRemotelyPeopleCount,
-        windfarmLocation: form.windfarmLocation,
-        windfarmPeopleCount: form.windfarmPeopleCount,
+        environment: form.environment || "",
+        activity: form.activity || "",
+        otherActivityText: form.otherActivityText || "",
+        otherActivityLocation: form.otherActivityLocation || "",
+        otherActivityPeopleCount: form.otherActivityPeopleCount || "",
+        workingRemotelyLocation: form.workingRemotelyLocation || "",
+        workingRemotelyPeopleCount: form.workingRemotelyPeopleCount || "",
+        windfarmLocation: form.windfarmLocation || "",
+        windfarmPeopleCount: form.windfarmPeopleCount || "",
       };
     },
     beaconUseToForm: (draftRegistration) => ({
-      environment: draftRegistration.environment,
-      activity: draftRegistration.activity,
-      otherActivityText: draftRegistration.otherActivityText,
-      otherActivityLocation: draftRegistration.otherActivityLocation,
-      otherActivityPeopleCount: draftRegistration.otherActivityPeopleCount,
-      workingRemotelyLocation: draftRegistration.workingRemotelyLocation,
-      workingRemotelyPeopleCount: draftRegistration.workingRemotelyPeopleCount,
-      windfarmLocation: draftRegistration.windfarmLocation,
-      windfarmPeopleCount: draftRegistration.windfarmPeopleCount,
+      environment: draftRegistration.environment || "",
+      activity: draftRegistration.activity || "",
+      otherActivityText: draftRegistration.otherActivityText || "",
+      otherActivityLocation: draftRegistration.otherActivityLocation || "",
+      otherActivityPeopleCount:
+        draftRegistration.otherActivityPeopleCount || "",
+      workingRemotelyLocation: draftRegistration.workingRemotelyLocation || "",
+      workingRemotelyPeopleCount:
+        draftRegistration.workingRemotelyPeopleCount || "",
+      windfarmLocation: draftRegistration.windfarmLocation || "",
+      windfarmPeopleCount: draftRegistration.windfarmPeopleCount || "",
     }),
   };
 
@@ -675,12 +677,12 @@ const validationRules = ({
 }: FormSubmission): FormManager => {
   const activityMatchingCondition = (activity: Activity) => ({
     dependsOn: "activity",
-    meetingCondition: (value) => value === activity,
+    meetingCondition: (value: Activity) => value === activity,
   });
 
   const environmentIsLandMatchingCondition = {
     dependsOn: "environment",
-    meetingCondition: (value) => value === Environment.LAND,
+    meetingCondition: (value: Environment) => value === Environment.LAND,
   };
 
   return new FormManager({

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -100,7 +100,7 @@ const AdditionalBeaconUse: FunctionComponent<AdditionalBeaconUseProps> = ({
   );
 };
 
-const confirmBeforeDelete = (use, index) =>
+const confirmBeforeDelete = (use: DraftBeaconUse, index: number) =>
   PageURLs.areYouSure +
   queryParams({
     action: "delete your " + prettyUseName(use) + " use",

--- a/src/pages/register-a-beacon/land-communications.tsx
+++ b/src/pages/register-a-beacon/land-communications.tsx
@@ -246,7 +246,7 @@ const validationRules = ({
 }: FormSubmission): FormManager => {
   const matchingConditionIsTrueForKey = (key: string) => ({
     dependsOn: key,
-    meetingCondition: (value) => value === "true",
+    meetingCondition: (value: string) => value === "true",
   });
 
   return new FormManager({


### PR DESCRIPTION
Updated type definitions to remove "implicit any" and replaced all instances of undefined in "register-a-beacon" form with empty string. This prevents an error that occurs in development mode that is caused by returning an object containing undefined from `getServerSideProps`