### PR TITLE
Dac fixes

### DIFF
--- a/cypress/integration/individual-pages/activity.spec.ts
+++ b/cypress/integration/individual-pages/activity.spec.ts
@@ -39,6 +39,8 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
         "Activity",
         requiredFieldErrorMessage
       );
+      whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
+      thenMyFocusMovesTo("#motor-vessel");
     });
 
     it("displays an error if 'Other activity' is selected, but no text is provided", () => {
@@ -67,6 +69,8 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
         "Activity",
         requiredFieldErrorMessage
       );
+      whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
+      thenMyFocusMovesTo("#fishing-vessel");
     });
 
     it("displays an error if 'Other activity' is selected, but no text is provided", () => {
@@ -95,6 +99,8 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
         "Activity",
         requiredFieldErrorMessage
       );
+      whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
+      thenMyFocusMovesTo("#jet-aircraft");
     });
 
     it("displays an error if 'Other activity' is selected, but no text is provided", () => {
@@ -123,6 +129,8 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
         "Activity",
         requiredFieldErrorMessage
       );
+      whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
+      thenMyFocusMovesTo("#passenger-plane");
     });
 
     it("displays an error if 'Other activity' is selected, but no text is provided", () => {
@@ -150,6 +158,17 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
     beforeEach(() => {
       givenIHaveSelected("#land");
       andIClickContinue();
+    });
+
+    it("displays an error if no activity is selected", () => {
+      whenIClickContinue();
+      thenIShouldSeeFormErrors(requiredFieldErrorMessage);
+      thenIShouldSeeAnErrorSummaryLinkThatContains(
+        "Activity",
+        requiredFieldErrorMessage
+      );
+      whenIClickOnTheErrorSummaryLinkContaining(requiredFieldErrorMessage);
+      thenMyFocusMovesTo("#driving");
     });
 
     describe("the Working remotely option", () => {

--- a/cypress/integration/individual-pages/purpose.spec.ts
+++ b/cypress/integration/individual-pages/purpose.spec.ts
@@ -3,7 +3,9 @@ import {
   andIHaveEnteredNoInformation,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
+  thenMyFocusMovesTo,
   whenIClickContinue,
+  whenIClickOnTheErrorSummaryLinkContaining,
 } from "../common/selectors-and-assertions.spec";
 
 describe("As a beacon owner, I want to submit the purpose for my beacon", () => {
@@ -12,13 +14,11 @@ describe("As a beacon owner, I want to submit the purpose for my beacon", () => 
     andIHaveEnteredNoInformation();
     whenIClickContinue();
     thenIShouldSeeAnErrorMessageThatContains(requiredFieldErrorMessage);
-    // TODO: Uncomment below assertions when issue #148 fixed.  Error link
-    // should move focus to first radio button.
-    //
-    // whenIClickOnTheErrorSummaryLinkContaining(
-    //   "purpose",
-    //   requiredFieldErrorMessage
-    // );
-    // thenMyFocusMovesTo("#pleasure");
+
+    whenIClickOnTheErrorSummaryLinkContaining(
+      "purpose",
+      requiredFieldErrorMessage
+    );
+    thenMyFocusMovesTo("#pleasure");
   });
 });

--- a/cypress/integration/individual-pages/signUpOrSignIn.spec.ts
+++ b/cypress/integration/individual-pages/signUpOrSignIn.spec.ts
@@ -1,0 +1,22 @@
+import { PageURLs } from "../../../src/lib/urls";
+import {
+  andIClickContinue,
+  givenIAmAt,
+  thenIShouldSeeFormErrors,
+  thenMyFocusMovesTo,
+  whenIClickOnTheErrorSummaryLinkContaining,
+} from "../common/selectors-and-assertions.spec";
+
+describe("Given that I have visited sign-up-or-sign-in", () => {
+  it("Displays an error if I have not selected an option", () => {
+    givenIAmAt(PageURLs.signUpOrSignIn);
+    andIHaveNotSelectedAnOption();
+    andIClickContinue();
+    thenIShouldSeeFormErrors("Please select an option");
+
+    whenIClickOnTheErrorSummaryLinkContaining("Please select an option");
+    thenMyFocusMovesTo("#signIn");
+  });
+});
+
+const andIHaveNotSelectedAnOption = () => null;

--- a/src/components/Aside.tsx
+++ b/src/components/Aside.tsx
@@ -20,7 +20,10 @@ const Aside: FunctionComponent<AsideProps> = ({
           {title}
         </h2>
       )}
-      <nav role="navigation" aria-labelledby="subsection-title">
+      <nav
+        role="navigation"
+        aria-labelledby={title != null ? "subsection-title" : null}
+      >
         {children}
       </nav>
     </aside>

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -33,7 +33,7 @@ export const SummaryListItem: FunctionComponent<SummaryListItemProps> = ({
       <dd className="govuk-summary-list__actions" key={i}>
         <a className="govuk-link" href={href}>
           {text}
-          <span className="govuk-visually-hidden">{href}</span>
+          <span className="govuk-visually-hidden">{labelText}</span>
         </a>
       </dd>
     ))}

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -11,6 +11,7 @@ interface SectionHeadingProps {
 
 interface AnchorLinkProps {
   href: string;
+  description?: string;
   children: ReactNode;
   classes?: string;
 }
@@ -39,16 +40,28 @@ export const SectionHeading: FunctionComponent<SectionHeadingProps> = ({
 
 export const AnchorLink: FunctionComponent<AnchorLinkProps> = ({
   href,
+  description,
   children,
   classes = "",
 }: AnchorLinkProps): JSX.Element => (
   <a href={href} className={"govuk-link " + classes}>
-    {children}
+    <>
+      {children}
+      {!!description && (
+        <span
+          data-testid="anchor-link-description"
+          className="govuk-visually-hidden"
+        >
+          {description}
+        </span>
+      )}
+    </>
   </a>
 );
 
 export const WarningLink: FunctionComponent<AnchorLinkProps> = ({
   href,
+  description,
   children,
 }: AnchorLinkProps): JSX.Element => (
   <a
@@ -56,7 +69,17 @@ export const WarningLink: FunctionComponent<AnchorLinkProps> = ({
     className="govuk-link govuk-link--no-visited-state"
     style={{ color: "#d4351c" }}
   >
-    {children}
+    <>
+      {children}
+      {!!description && (
+        <span
+          data-testid="warning-link-description"
+          className="govuk-visually-hidden"
+        >
+          {description}
+        </span>
+      )}
+    </>
   </a>
 );
 

--- a/src/components/domain/BeaconUseSection.tsx
+++ b/src/components/domain/BeaconUseSection.tsx
@@ -18,6 +18,8 @@ export const BeaconUseSection: FunctionComponent<BeaconUseSectionProps> = ({
   changeUri,
   deleteUri,
 }: BeaconUseSectionProps): JSX.Element => {
+  const description = "The main use of this beacon";
+
   return (
     <>
       <div
@@ -36,12 +38,17 @@ export const BeaconUseSection: FunctionComponent<BeaconUseSectionProps> = ({
           {changeUri && (
             <AnchorLink
               href={changeUri}
+              description={description}
               classes="govuk-link--no-visited-state govuk-!-margin-right-4"
             >
               Change
             </AnchorLink>
           )}
-          {deleteUri && <WarningLink href={deleteUri}>Delete</WarningLink>}
+          {deleteUri && (
+            <WarningLink href={deleteUri} description={description}>
+              Delete
+            </WarningLink>
+          )}
         </div>
       </div>
 

--- a/src/components/domain/BeaconUseSection.tsx
+++ b/src/components/domain/BeaconUseSection.tsx
@@ -18,7 +18,7 @@ export const BeaconUseSection: FunctionComponent<BeaconUseSectionProps> = ({
   changeUri,
   deleteUri,
 }: BeaconUseSectionProps): JSX.Element => {
-  const description = "The main use of this beacon";
+  const useRank = sentenceCase(ordinal(index + 1)) + " use";
 
   return (
     <>
@@ -31,21 +31,21 @@ export const BeaconUseSection: FunctionComponent<BeaconUseSectionProps> = ({
         }}
       >
         <SectionHeading classes="govuk-!-margin-0">
-          {sentenceCase(ordinal(index + 1) + " use: ") + prettyUseName(use)}
+          {useRank + ": " + prettyUseName(use)}
         </SectionHeading>
 
         <div>
           {changeUri && (
             <AnchorLink
               href={changeUri}
-              description={description}
+              description={useRank}
               classes="govuk-link--no-visited-state govuk-!-margin-right-4"
             >
               Change
             </AnchorLink>
           )}
           {deleteUri && (
-            <WarningLink href={deleteUri} description={description}>
+            <WarningLink href={deleteUri} description={useRank}>
               Delete
             </WarningLink>
           )}

--- a/src/lib/form/FieldManager.ts
+++ b/src/lib/form/FieldManager.ts
@@ -19,14 +19,21 @@ export class FieldManager extends AbstractFormNode {
   private _keywordMap = {
     HEX_ID_COUNTRY: (hexId) => HexIdParser.countryName(hexId),
   };
+  /**
+   * Assign to fieldId the id of an element that needs to be focused when
+   * skipping to error.  E.g. the first element in a `RadioList`
+   */
+  public readonly fieldId?: string;
 
   constructor(
     value: string,
     public readonly validators: ValidationRule[] = [],
-    public readonly conditions: ValidationCondition[] = []
+    public readonly conditions: ValidationCondition[] = [],
+    fieldId?: string
   ) {
     super(value);
     this._value = value ? value : "";
+    this.fieldId = fieldId;
   }
 
   /**

--- a/src/lib/form/FormManager.ts
+++ b/src/lib/form/FormManager.ts
@@ -110,7 +110,7 @@ export class FormManager extends AbstractFormNode {
       .map((fieldId) => {
         const fieldInput = this.fields[fieldId];
         return {
-          fieldId,
+          fieldId: fieldInput.fieldId || fieldId,
           errorMessages: fieldInput.errorMessages(),
         };
       });

--- a/src/pages/account/sign-up-or-sign-in.tsx
+++ b/src/pages/account/sign-up-or-sign-in.tsx
@@ -84,9 +84,12 @@ export const getServerSideProps: GetServerSideProps = withContainer(
 
 const validationRules = ({ signUpOrSignIn }) => {
   return new FormManager({
-    signUpOrSignIn: new FieldManager(signUpOrSignIn, [
-      Validators.required("Please select an option"),
-    ]),
+    signUpOrSignIn: new FieldManager(
+      signUpOrSignIn,
+      [Validators.required("Please select an option")],
+      undefined,
+      "signIn"
+    ),
   });
 };
 

--- a/src/pages/account/sign-up-or-sign-in.tsx
+++ b/src/pages/account/sign-up-or-sign-in.tsx
@@ -87,7 +87,7 @@ const validationRules = ({ signUpOrSignIn }) => {
     signUpOrSignIn: new FieldManager(
       signUpOrSignIn,
       [Validators.required("Please select an option")],
-      undefined,
+      [],
       "signIn"
     ),
   });

--- a/src/pages/account/your-beacon-registry-account.tsx
+++ b/src/pages/account/your-beacon-registry-account.tsx
@@ -83,6 +83,7 @@ const YourDetails: FunctionComponent<IYourDetailsProps> = ({
           <AnchorLink
             href={PageURLs.updateAccount}
             classes="govuk-link--no-visited-state govuk-!-margin-right-4"
+            description="Your details"
           >
             Change
           </AnchorLink>

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -694,7 +694,7 @@ const validationRules = ({
     activity: new FieldManager(
       activity,
       [Validators.required("Activity is a required field")],
-      undefined,
+      [],
       fieldToFocus(environment, purpose)
     ),
     otherActivityText: new FieldManager(

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -656,6 +656,7 @@ const mapper = (
         draftRegistration.workingRemotelyPeopleCount || "",
       windfarmLocation: draftRegistration.windfarmLocation || "",
       windfarmPeopleCount: draftRegistration.windfarmPeopleCount || "",
+      purpose: draftRegistration.purpose,
     }),
   };
 
@@ -674,6 +675,7 @@ const validationRules = ({
   workingRemotelyPeopleCount,
   windfarmLocation,
   windfarmPeopleCount,
+  purpose,
 }: FormSubmission): FormManager => {
   const activityMatchingCondition = (activity: Activity) => ({
     dependsOn: "activity",
@@ -685,11 +687,16 @@ const validationRules = ({
     meetingCondition: (value: Environment) => value === Environment.LAND,
   };
 
+  fieldToFocus(environment, purpose);
+
   return new FormManager({
     environment: new FieldManager(environment),
-    activity: new FieldManager(activity, [
-      Validators.required("Activity is a required field"),
-    ]),
+    activity: new FieldManager(
+      activity,
+      [Validators.required("Activity is a required field")],
+      undefined,
+      fieldToFocus(environment, purpose)
+    ),
     otherActivityText: new FieldManager(
       otherActivityText,
       [Validators.required("Enter a description for your activity")],
@@ -753,6 +760,26 @@ const validationRules = ({
       [activityMatchingCondition(Activity.WINDFARM)]
     ),
   });
+};
+
+const fieldToFocus = (
+  environment: Environment | undefined,
+  purpose: Purpose | undefined
+) => {
+  switch (environment) {
+    case Environment.MARITIME:
+      if (purpose === Purpose.COMMERCIAL) {
+        return "fishing-vessel";
+      }
+      return "motor-vessel";
+    case Environment.AVIATION:
+      if (purpose === Purpose.COMMERCIAL) {
+        return "passenger-plane";
+      }
+      return "jet-aircraft";
+    case Environment.LAND:
+      return "driving";
+  }
 };
 
 export default ActivityPage;

--- a/src/pages/register-a-beacon/beacon-use.tsx
+++ b/src/pages/register-a-beacon/beacon-use.tsx
@@ -167,9 +167,12 @@ const mapper = (context: BeaconsGetServerSidePropsContext) => {
 
 const validationRules = ({ environment }) => {
   return new FormManager({
-    environment: new FieldManager(environment, [
-      Validators.required("Where the beacon will be used is required"),
-    ]),
+    environment: new FieldManager(
+      environment,
+      [Validators.required("Where the beacon will be used is required")],
+      undefined,
+      "maritime"
+    ),
   });
 };
 

--- a/src/pages/register-a-beacon/beacon-use.tsx
+++ b/src/pages/register-a-beacon/beacon-use.tsx
@@ -170,7 +170,7 @@ const validationRules = ({ environment }) => {
     environment: new FieldManager(
       environment,
       [Validators.required("Where the beacon will be used is required")],
-      undefined,
+      [],
       "maritime"
     ),
   });

--- a/src/pages/register-a-beacon/purpose.tsx
+++ b/src/pages/register-a-beacon/purpose.tsx
@@ -138,7 +138,7 @@ const validationRules = ({ purpose }: FormSubmission): FormManager => {
     purpose: new FieldManager(
       purpose,
       [Validators.required("Beacon use purpose is a required field")],
-      undefined,
+      [],
       "pleasure"
     ),
   });

--- a/src/pages/register-a-beacon/purpose.tsx
+++ b/src/pages/register-a-beacon/purpose.tsx
@@ -135,9 +135,12 @@ const mapper = (context: BeaconsGetServerSidePropsContext) => {
 
 const validationRules = ({ purpose }: FormSubmission): FormManager => {
   return new FormManager({
-    purpose: new FieldManager(purpose, [
-      Validators.required("Beacon use purpose is a required field"),
-    ]),
+    purpose: new FieldManager(
+      purpose,
+      [Validators.required("Beacon use purpose is a required field")],
+      undefined,
+      "pleasure"
+    ),
   });
 };
 

--- a/test/components/Typography.test.tsx
+++ b/test/components/Typography.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { AnchorLink } from "../../src/components/Typography";
+
+describe("Typography Components", () => {
+  describe("AnchorLink", () => {
+    it("should render a visually hidden span with a description if provided with a description", () => {
+      const { getByTestId } = render(
+        <AnchorLink href="#" description="Description">
+          Text
+        </AnchorLink>
+      );
+
+      expect(getByTestId("anchor-link-description")).toBeDefined();
+    });
+
+    it("should not render a visually hidden span if description not provided", () => {
+      const { queryByTestId } = render(<AnchorLink href="#">Text</AnchorLink>);
+
+      expect(queryByTestId("anchor-link-description")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Acceptance criteria in PR

- A: Ensure "error summary skip links" take users to the input that they relate to. This is currently not functioning when linking to `RadioGroup` or `Checkbox` in forms.
- A: Incorrect use of Aria(1):  In `Aside` component, `<nav>` must not have `aria-labelledby` when there is no label.
- A: Non-Descriptive Links in Context (1): On page `/register-a-beacon/check-your-answers`: Text in hidden span describing the "change" link needs to be reformatted from link style text to plain text.
- A: Non-Descriptive Links in Context (2): On page `/register-a-beacon/additional-beacon-use`: Add visually hidden spans to make purpose of "change" and "delete" links clearer.

## Link to Trello Card
https://trello.com/c/JRR0dHIF/936-dacs-feedback

closes #148 