### PR TITLE
fieldset & legend issue 3 changes

### DIFF
--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from "next";
 import React, { FunctionComponent, ReactNode } from "react";
 import { BeaconsForm } from "../../components/BeaconsForm";
 import { CheckboxList, CheckboxListItem } from "../../components/Checkbox";
-import { FormFieldset, FormGroup, FormLegend } from "../../components/Form";
+import { FormGroup } from "../../components/Form";
 import { Input } from "../../components/Input";
 import { TextareaCharacterCount } from "../../components/Textarea";
 import { AnchorLink, GovUKBody } from "../../components/Typography";
@@ -53,13 +53,6 @@ const VesselCommunications: FunctionComponent<DraftBeaconUsePageProps> = ({
       <GovUKBody>
         This will be critical for Search and Rescue in an emergency.
       </GovUKBody>
-      <GovUKBody>
-        If you have a radio license, VHF and/or VHF/DSC radio, you can{" "}
-        <AnchorLink href={ofcomLicenseUrl}>
-          find up your Call Sign and Maritime Mobile Service Identity (MMSI)
-          number on the OFCOM website.
-        </AnchorLink>
-      </GovUKBody>
     </>
   );
 
@@ -72,9 +65,8 @@ const VesselCommunications: FunctionComponent<DraftBeaconUsePageProps> = ({
       pageText={pageText}
       headingType="legend"
     >
-      <CallSign value={form.fields.callSign.value} />
-
       <TypesOfCommunication form={form} />
+      <CallSign value={form.fields.callSign.value} />
     </BeaconsForm>
   );
 };
@@ -87,6 +79,13 @@ const CallSign: FunctionComponent<FormInputProps> = ({
   value,
 }: FormInputProps) => (
   <>
+    <GovUKBody>
+      If you have a radio license, VHF and/or VHF/DSC radio, you can{" "}
+      <AnchorLink href={ofcomLicenseUrl}>
+        find your Call Sign and Maritime Mobile Service Identity (MMSI) number
+        on the OFCOM website.
+      </AnchorLink>
+    </GovUKBody>
     <FormGroup className="govuk-!-margin-top-4">
       <Input
         id="callSign"
@@ -105,11 +104,10 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 }: {
   form: FormJSON;
 }) => (
-  <FormFieldset>
-    <FormLegend size="small">
+  <>
+    <h2 className="govuk-heading-s govuk-!-margin-bottom-1">
       Tick all that apply and provide as much detail as you can
-    </FormLegend>
-
+    </h2>
     <FormGroup>
       <CheckboxList conditional={true}>
         <CheckboxListItem
@@ -213,7 +211,7 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
         </CheckboxListItem>
       </CheckboxList>
     </FormGroup>
-  </FormFieldset>
+  </>
 );
 
 export const getServerSideProps: GetServerSideProps = withContainer(


### PR DESCRIPTION
**Issue:** On page register-a-beacon/vessel-communications the fieldset containing the checkboxes uses "Tick all that apply and provide as much detail as you can" as the legend. This is not descriptive enough out of context, and the fact that the input is optional is not clear enough.

**Solution:** GDS guidelines for fieldset recommend using the page header/question as the legend for these types offieldset elements. DAC recommends restructuring the form to make it possible to use the page header as the legend for this checkbox.

**Before:**
<img width="579" alt="Screenshot 2021-08-23 at 14 55 03" src="https://user-images.githubusercontent.com/88549170/130459650-6fbfd40c-c659-4651-b0b8-8e1616a077b2.png">

**After:**
![image](https://user-images.githubusercontent.com/88549170/130459492-902b5444-d554-4024-a852-b712432d7925.png)

**Trello ticket:**
https://trello.com/c/DXErqUWz/988-dac-fieldset-and-legend-usage