### PR TITLE
Refactor check-beacon-details page

### DIFF
--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -5,6 +5,7 @@ import { BeaconsForm } from "../../components/BeaconsForm";
 import { Details } from "../../components/Details";
 import { FormGroup } from "../../components/Form";
 import { FormInputProps, Input } from "../../components/Input";
+import { GovUKBody } from "../../components/Typography";
 import { FieldManager } from "../../lib/form/FieldManager";
 import { FormManager } from "../../lib/form/FormManager";
 import { Validators } from "../../lib/form/Validators";
@@ -27,6 +28,17 @@ interface CheckBeaconDetailsForm {
   hexId: string;
 }
 
+interface BeaconDetailProps extends DraftRegistrationPageProps {
+  pageHeading: string;
+  pageText: string;
+  previousPageUrl: string;
+  isUpdate?: boolean;
+}
+
+interface ExistingBeaconHexIdProps {
+  hexId: string;
+}
+
 const CheckBeaconDetails: FunctionComponent<DraftRegistrationPageProps> = ({
   form,
   showCookieBanner,
@@ -35,10 +47,35 @@ const CheckBeaconDetails: FunctionComponent<DraftRegistrationPageProps> = ({
   const pageText =
     "The details of your beacon must be checked to ensure it is programmed for UK registration.";
 
+  // const pageHeading = "Beacon details";
+  // const pageText =
+  //   "The UIN / HEX ID of a registered beacon is not editable. If you wish to change the beacon HEX ID, you must first delete the beacon record and register the new UID/HEX ID as new beacon record.";
+
+  return (
+    <BeaconDetails
+      form={form}
+      showCookieBanner={showCookieBanner}
+      pageHeading={pageHeading}
+      pageText={pageText}
+      previousPageUrl={"/"}
+      isUpdate={false}
+      // isUpdate={true}
+    />
+  );
+};
+
+const BeaconDetails: FunctionComponent<BeaconDetailProps> = ({
+  form,
+  showCookieBanner,
+  pageHeading,
+  pageText,
+  previousPageUrl,
+  isUpdate,
+}: BeaconDetailProps): JSX.Element => {
   return (
     <BeaconsForm
       formErrors={form.errorSummary}
-      previousPageUrl="/"
+      previousPageUrl={previousPageUrl}
       includeUseIndex={false}
       pageHeading={pageHeading}
       showCookieBanner={showCookieBanner}
@@ -53,10 +90,14 @@ const CheckBeaconDetails: FunctionComponent<DraftRegistrationPageProps> = ({
         value={form.fields.model.value}
         errorMessages={form.fields.model.errorMessages}
       />
-      <BeaconHexIdInput
-        value={form.fields.hexId.value}
-        errorMessages={form.fields.hexId.errorMessages}
-      />
+      {isUpdate ? (
+        <ExistingBeaconHexId hexId={form.fields.hexId.value} />
+      ) : (
+        <BeaconHexIdInput
+          value={form.fields.hexId.value}
+          errorMessages={form.fields.hexId.errorMessages}
+        />
+      )}
     </BeaconsForm>
   );
 };
@@ -83,6 +124,21 @@ const BeaconModelInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
+const HexIdHelp: FunctionComponent = (): JSX.Element => (
+  <Details
+    summaryText="What does the 15 character beacon HEX ID or UIN look like?"
+    className="govuk-!-padding-top-2"
+  >
+    <Image
+      src="/assets/mca_images/beacon_hex_id.png"
+      alt="This image illustrates what a beacon's HEX ID or UIN number looks like on an actual
+        beacon. The example HEX ID or UIN here is 1D0EA08C52FFBFF."
+      height={640}
+      width={960}
+    />
+  </Details>
+);
+
 const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
   value = "",
   errorMessages,
@@ -96,19 +152,19 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
       htmlAttributes={{ spellCheck: false }}
       defaultValue={value}
     />
-    <Details
-      summaryText="What does the 15 character beacon HEX ID or UIN look like?"
-      className="govuk-!-padding-top-2"
-    >
-      <Image
-        src="/assets/mca_images/beacon_hex_id.png"
-        alt="This image illustrates what a beacon's HEX ID or UIN number looks like on an actual
-        beacon. The example HEX ID or UIN here is 1D0EA08C52FFBFF."
-        height={640}
-        width={960}
-      />
-    </Details>
+    <HexIdHelp />
   </FormGroup>
+);
+
+const ExistingBeaconHexId: FunctionComponent<ExistingBeaconHexIdProps> = ({
+  hexId,
+}: ExistingBeaconHexIdProps): JSX.Element => (
+  <>
+    <br />
+    <GovUKBody>The 15 character beacon HEX ID or UIN number</GovUKBody>
+    <GovUKBody>Hex ID/UIN: {hexId}</GovUKBody>
+    <HexIdHelp />
+  </>
 );
 
 export const getServerSideProps: GetServerSideProps = withContainer(

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -32,7 +32,7 @@ interface BeaconDetailProps extends DraftRegistrationPageProps {
   pageHeading: string;
   pageText: string;
   previousPageUrl: string;
-  isUpdate?: boolean;
+  isUpdate: boolean;
 }
 
 interface ExistingBeaconHexIdProps {
@@ -47,10 +47,6 @@ const CheckBeaconDetails: FunctionComponent<DraftRegistrationPageProps> = ({
   const pageText =
     "The details of your beacon must be checked to ensure it is programmed for UK registration.";
 
-  // const pageHeading = "Beacon details";
-  // const pageText =
-  //   "The UIN / HEX ID of a registered beacon is not editable. If you wish to change the beacon HEX ID, you must first delete the beacon record and register the new UID/HEX ID as new beacon record.";
-
   return (
     <BeaconDetails
       form={form}
@@ -59,7 +55,6 @@ const CheckBeaconDetails: FunctionComponent<DraftRegistrationPageProps> = ({
       pageText={pageText}
       previousPageUrl={"/"}
       isUpdate={false}
-      // isUpdate={true}
     />
   );
 };


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The user journey for updating a beacon is going to be _very_ similar to the one we have for registering a beacon.

So we want to make the components in the `/register-a-beacon/` pages to be resuable for when we add the _update_ pages.
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

How it looks now for registering a beacon:
<img src="https://user-images.githubusercontent.com/32230328/130760230-5b5eaf56-8024-4aa5-8b4b-20fcd1a92452.png" height=300px></img>

How it'll look for update, by just changing the props for `BeaconDetails` component:
<img src="https://user-images.githubusercontent.com/32230328/130760450-f23b31ba-9dd8-4556-be52-92a6b01c0298.png" height=300px></img>

## Guidance for review
Please shout if you come up with better names for the components/props
 - e.g.  is `isUpdate` clear enough 😅 

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/BbG4BwRD/823-spike-beacon-account-holder-user-can-update-beacon

