### PR TITLE
Map single beacon from API response

### DIFF
--- a/src/gateways/mappers/BeaconsApiResponseMapper.ts
+++ b/src/gateways/mappers/BeaconsApiResponseMapper.ts
@@ -4,34 +4,47 @@ import { EntityLink } from "../../entities/EntityLink";
 import { Owner } from "../../entities/Owner";
 import { Use } from "../../entities/Use";
 import { isoDate } from "../../lib/dateTime";
+import { IApiResponse } from "./IApiResponse";
 import { IBeaconDataAttributes } from "./IBeaconDataAttributes";
 import { IBeaconListResponse } from "./IBeaconListResponse";
+import { IBeaconResponse } from "./IBeaconResponse";
 import { IBeaconResponseMapper } from "./IBeaconResponseMapper";
 
 export class BeaconsApiResponseMapper implements IBeaconResponseMapper {
+  public map(beaconApiResponse: IBeaconResponse): Beacon {
+    return this.mapToBeacon(beaconApiResponse, beaconApiResponse.data);
+  }
+
   public mapList(beaconApiResponse: IBeaconListResponse): Beacon[] {
-    return beaconApiResponse.data.map((beacon) => {
-      return {
-        id: beacon.id,
-        hexId: beacon.attributes.hexId,
-        type: beacon.attributes.type || "",
-        manufacturer: beacon.attributes.manufacturer || "",
-        model: beacon.attributes.model || "",
-        status: beacon.attributes.status || "",
-        registeredDate: isoDate(beacon.attributes.createdDate || ""),
-        batteryExpiryDate: isoDate(beacon.attributes.batteryExpiryDate || ""),
-        chkCode: beacon.attributes.chkCode || "",
-        protocolCode: beacon.attributes.protocolCode || "",
-        codingMethod: beacon.attributes.codingMethod || "",
-        lastServicedDate: isoDate(beacon.attributes.lastServicedDate || ""),
-        manufacturerSerialNumber:
-          beacon.attributes.manufacturerSerialNumber || "",
-        owners: this.mapOwners(beaconApiResponse, beacon),
-        emergencyContacts: this.mapEmergencyContacts(beaconApiResponse, beacon),
-        uses: this.mapUses(beaconApiResponse, beacon),
-        entityLinks: this.mapLinks(beacon.links),
-      };
+    return beaconApiResponse.data.map((beaconData) => {
+      return this.mapToBeacon(beaconApiResponse, beaconData);
     });
+  }
+
+  private mapToBeacon(
+    response: IApiResponse,
+    beaconData: IBeaconDataAttributes
+  ): Beacon {
+    return {
+      id: beaconData.id,
+      hexId: beaconData.attributes.hexId,
+      type: beaconData.attributes.type || "",
+      manufacturer: beaconData.attributes.manufacturer || "",
+      model: beaconData.attributes.model || "",
+      status: beaconData.attributes.status || "",
+      registeredDate: isoDate(beaconData.attributes.createdDate || ""),
+      batteryExpiryDate: isoDate(beaconData.attributes.batteryExpiryDate || ""),
+      chkCode: beaconData.attributes.chkCode || "",
+      protocolCode: beaconData.attributes.protocolCode || "",
+      codingMethod: beaconData.attributes.codingMethod || "",
+      lastServicedDate: isoDate(beaconData.attributes.lastServicedDate || ""),
+      manufacturerSerialNumber:
+        beaconData.attributes.manufacturerSerialNumber || "",
+      owners: this.mapOwners(response, beaconData),
+      emergencyContacts: this.mapEmergencyContacts(response, beaconData),
+      uses: this.mapUses(response, beaconData),
+      entityLinks: this.mapLinks(beaconData.links),
+    };
   }
 
   private mapLinks(links: EntityLink[]): EntityLink[] {
@@ -41,7 +54,7 @@ export class BeaconsApiResponseMapper implements IBeaconResponseMapper {
   }
 
   private mapOwners(
-    beaconApiResponse: IBeaconListResponse,
+    beaconApiResponse: IApiResponse,
     beacon: IBeaconDataAttributes
   ): Owner[] {
     const ownerIds = beacon.relationships.owner.data.map((owner) => owner.id);
@@ -70,7 +83,7 @@ export class BeaconsApiResponseMapper implements IBeaconResponseMapper {
   }
 
   private mapEmergencyContacts(
-    beaconApiResponse: IBeaconListResponse,
+    beaconApiResponse: IApiResponse,
     beacon: IBeaconDataAttributes
   ): EmergencyContact[] {
     const emergencyContactIds = beacon.relationships.emergencyContacts.data.map(
@@ -98,7 +111,7 @@ export class BeaconsApiResponseMapper implements IBeaconResponseMapper {
   }
 
   private mapUses(
-    beaconApiResponse: IBeaconListResponse,
+    beaconApiResponse: IApiResponse,
     beacon: IBeaconDataAttributes
   ): Use[] {
     return beaconApiResponse.included

--- a/src/gateways/mappers/IBeaconResponseMapper.ts
+++ b/src/gateways/mappers/IBeaconResponseMapper.ts
@@ -1,6 +1,8 @@
 import { Beacon } from "../../entities/Beacon";
 import { IBeaconListResponse } from "./IBeaconListResponse";
+import { IBeaconResponse } from "./IBeaconResponse";
 
 export interface IBeaconResponseMapper {
+  map: (beaconApiResponse: IBeaconResponse) => Beacon;
   mapList: (beaconApiResponse: IBeaconListResponse) => Beacon[];
 }

--- a/test/fixtures/singleBeaconApiResponse.fixture.ts
+++ b/test/fixtures/singleBeaconApiResponse.fixture.ts
@@ -76,7 +76,6 @@ export const singleBeaconApiResponseFixture: IBeaconResponse = deepFreeze({
       uses: {
         data: [
           { type: "beaconUse", id: "e00036c4-e3f4-46bb-aa9e-1d91870d9172" },
-          { type: "beaconUse", id: "e00036c4-e3f4-46bb-aa9e-1d91870d9173" },
         ],
       },
       owner: {
@@ -102,19 +101,6 @@ export const singleBeaconApiResponseFixture: IBeaconResponse = deepFreeze({
     },
   },
   included: [
-    {
-      type: "beaconUse",
-      id: "e00036c4-e3f4-46bb-aa9e-1d91870d9173",
-      attributes: {
-        ...getUseResponseJson(false),
-      },
-      links: [
-        {
-          verb: "PATCH",
-          path: "/beacon-uses/e00036c4-e3f4-46bb-aa9e-1d91870d9173",
-        },
-      ],
-    },
     {
       type: "beaconUse",
       id: "e00036c4-e3f4-46bb-aa9e-1d91870d9172",

--- a/test/gateways/BeaconsApiResponseMapper.test.ts
+++ b/test/gateways/BeaconsApiResponseMapper.test.ts
@@ -1,24 +1,34 @@
 import * as _ from "lodash";
 import { Beacon } from "../../src/entities/Beacon";
 import { BeaconsApiResponseMapper } from "../../src/gateways/mappers/BeaconsApiResponseMapper";
-import { IBeaconListResponse } from "../../src/gateways/mappers/IBeaconListResponse";
 import { beaconFixtures } from "../fixtures/beacons.fixture";
 import { manyBeaconsApiResponseFixture } from "../fixtures/manyBeaconsApiResponse.fixture";
+import { singleBeaconApiResponseFixture } from "../fixtures/singleBeaconApiResponse.fixture";
 
 describe("BeaconsApiResponseMapper", () => {
-  let beaconApiListResponse: IBeaconListResponse;
+  let responseMapper: BeaconsApiResponseMapper;
+  let beaconApiResponse;
 
-  let expectedBeacon: Beacon[];
+  let expectedBeacons: Beacon[];
+  let expectedBeacon: Beacon;
 
   beforeEach(() => {
-    beaconApiListResponse = _.cloneDeep(manyBeaconsApiResponseFixture);
-    expectedBeacon = _.cloneDeep(beaconFixtures);
+    responseMapper = new BeaconsApiResponseMapper();
+    expectedBeacons = _.cloneDeep(beaconFixtures);
+    expectedBeacon = expectedBeacons[0];
+  });
+
+  it("maps a beacon API response containing a single beacon to a Beacon", () => {
+    beaconApiResponse = _.cloneDeep(singleBeaconApiResponseFixture);
+    const mappedBeacon = responseMapper.map(beaconApiResponse);
+
+    expect(mappedBeacon).toStrictEqual(expectedBeacon);
   });
 
   it("maps a beacon API response containing multiple beacons to an Beacon array", () => {
-    const responseMapper = new BeaconsApiResponseMapper();
+    beaconApiResponse = _.cloneDeep(manyBeaconsApiResponseFixture);
+    const mappedBeacons = responseMapper.mapList(beaconApiResponse);
 
-    const mappedBeacon = responseMapper.mapList(beaconApiListResponse);
-    expect(mappedBeacon).toStrictEqual(expectedBeacon);
+    expect(mappedBeacons).toStrictEqual(expectedBeacons);
   });
 });


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
For the [Beacon Summary page](https://miro.com/app/board/o9J_lZuM9qs=/?moveToWidget=3074457358249941097&cot=14), we'll need to get a single beacon from the Service, which means we'll have to map from a single beacon API response into a `Beacon` entity.

We already map an array of beacons.

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Modify the `BeaconApiMapper` to also map a `Beacon` from an `IBeaconResponse`

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->
https://trello.com/c/FyHEXmlc/1016-spike-beacon-account-holder-user-can-update-beacon

