### PR TITLE
Require logged in state

### DIFF
--- a/cypress/integration/common/selectors-and-assertions.spec.ts
+++ b/cypress/integration/common/selectors-and-assertions.spec.ts
@@ -33,10 +33,8 @@ export const givenIHaveSignedIn = (): void => {
   });
 };
 
-export const givenIDoNotHaveAValidSession = (): void => {
-  cy.setCookie("next-auth.session-token", "not-a-valid-token", {
-    log: false,
-  });
+export const givenIHaveNotSignedIn = (): void => {
+  cy.clearCookie("next-auth.session-token");
 };
 
 export const givenIAmAt = (url: string): void => {

--- a/cypress/integration/common/selectors-and-assertions.spec.ts
+++ b/cypress/integration/common/selectors-and-assertions.spec.ts
@@ -33,6 +33,12 @@ export const givenIHaveSignedIn = (): void => {
   });
 };
 
+export const givenIDoNotHaveAValidSession = (): void => {
+  cy.setCookie("next-auth.session-token", "not-a-valid-token", {
+    log: false,
+  });
+};
+
 export const givenIAmAt = (url: string): void => {
   cy.visit(url);
 };

--- a/cypress/integration/individual-pages/aboutBeaconOwner.spec.ts
+++ b/cypress/integration/individual-pages/aboutBeaconOwner.spec.ts
@@ -1,6 +1,7 @@
 import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -17,6 +18,7 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
   const telephoneNumberInputFieldSelector = "#ownerTelephoneNumber";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/aboutTheAircraft.spec.ts
+++ b/cypress/integration/individual-pages/aboutTheAircraft.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   givenIHaveTyped,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
@@ -19,6 +20,7 @@ describe("As a beacon owner, I want to submit information about my aircraft", ()
   const beaconPositionSelector = "#beaconPosition";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/aboutTheVessel.spec.ts
+++ b/cypress/integration/individual-pages/aboutTheVessel.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   givenIHaveTyped,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
@@ -21,6 +22,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   const beaconLocationFieldSelector = "#beaconLocation";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/activity.spec.ts
+++ b/cypress/integration/individual-pages/activity.spec.ts
@@ -3,6 +3,7 @@ import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
   givenIHaveSelected,
+  givenIHaveSignedIn,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -21,6 +22,7 @@ describe("As a beacon owner, I want to submit the primary activity for my beacon
   ];
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(PageURLs.environment);
   });
 

--- a/cypress/integration/individual-pages/aircraftCommunications.spec.ts
+++ b/cypress/integration/individual-pages/aircraftCommunications.spec.ts
@@ -2,6 +2,7 @@ import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
   givenIHaveSelected,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -23,6 +24,7 @@ describe("As a beacon owner, I want to register details about the aircraft commu
   const otherCommunicationInputSelector = "#otherCommunicationInput";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(pageUrl);
   });
 

--- a/cypress/integration/individual-pages/beaconInformation.spec.ts
+++ b/cypress/integration/individual-pages/beaconInformation.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   iCanSeeAPageHeadingThatContains,
   requiredFieldErrorMessage,
@@ -31,6 +32,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   const validMonth = "12";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(pageUrl);
   });
 

--- a/cypress/integration/individual-pages/beaconOwnerAddress.spec.ts
+++ b/cypress/integration/individual-pages/beaconOwnerAddress.spec.ts
@@ -2,6 +2,7 @@ import {
   andIClickContinue,
   andIType,
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
@@ -23,6 +24,7 @@ describe("As a beacon owner I can enter my address so I will receive physical ev
   const beaconOwnerPostcodeSelector = "#ownerPostcode";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/beaconUse.spec.ts
+++ b/cypress/integration/individual-pages/beaconUse.spec.ts
@@ -2,6 +2,7 @@ import { PageURLs } from "../../../src/lib/urls";
 import {
   givenIHaveACookieSetAndIVisit,
   givenIHaveSelected,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   iCanSeeAPageHeadingThatContains,
   thenTheUrlShouldContain,
@@ -10,6 +11,7 @@ import {
 
 describe("As a beacon owner, I want to submit uses for my beacon", () => {
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(PageURLs.environment);
   });
 

--- a/cypress/integration/individual-pages/checkBeaconDetails.spec.ts
+++ b/cypress/integration/individual-pages/checkBeaconDetails.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   iCanSeeAPageHeadingThatContains,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -17,6 +18,7 @@ describe("As a beacon owner, I want to enter my initial beacon information", () 
   const hexIdFieldSelector = "#hexId";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(pageUrl);
   });
 

--- a/cypress/integration/individual-pages/checkYourAnswers.spec.ts
+++ b/cypress/integration/individual-pages/checkYourAnswers.spec.ts
@@ -7,6 +7,7 @@ import {
   andIAmAt,
   givenIHaveACookieSetAndIVisit,
   givenIHaveClicked,
+  givenIHaveSignedIn,
   iCanSeeAPageHeadingThatContains,
 } from "../common/selectors-and-assertions.spec";
 
@@ -16,11 +17,13 @@ describe("As a beacon owner, I want to check the details that were submitted", (
   const startButtonSelector = ".govuk-button--start";
 
   it("should display the page title", () => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(PageURLs.checkYourAnswers);
     iCanSeeAPageHeadingThatContains("Check your answers");
   });
 
   it("should not clear the form when I click Accept and Send and the registration fails", () => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(PageURLs.beaconInformation);
     givenIHaveFilledInCheckBeaconDetailsPage();
     andIAmAt(PageURLs.checkYourAnswers);

--- a/cypress/integration/individual-pages/emergencyContact.spec.ts
+++ b/cypress/integration/individual-pages/emergencyContact.spec.ts
@@ -1,5 +1,6 @@
 import {
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
@@ -20,6 +21,7 @@ describe("As a beacon owner, I want to submit information about my beacon", () =
   const emergencyContact1TelephoneNumber = "#emergencyContact1TelephoneNumber";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/landCommunications.spec.ts
+++ b/cypress/integration/individual-pages/landCommunications.spec.ts
@@ -4,6 +4,7 @@ import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
   givenIHaveSelected,
+  givenIHaveSignedIn,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
   thenMyFocusMovesTo,
@@ -24,6 +25,7 @@ describe("As a beacon owner and land or other use user", () => {
   const otherCommunicationInputSelector = "#otherCommunicationInput";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(PageURLs.landCommunications);
   });
 

--- a/cypress/integration/individual-pages/moreDetails.spec.ts
+++ b/cypress/integration/individual-pages/moreDetails.spec.ts
@@ -1,6 +1,7 @@
 import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -17,6 +18,7 @@ describe("As a beacon owner I want to submit more information about my beacon", 
   const moreDetailsTextareaSelector = "#moreDetails";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(thisPageUrl);
   });
 

--- a/cypress/integration/individual-pages/myInvalidFormRemainsWhenIRefreshThePage.spec.ts
+++ b/cypress/integration/individual-pages/myInvalidFormRemainsWhenIRefreshThePage.spec.ts
@@ -2,6 +2,7 @@ import { PageURLs } from "../../../src/lib/urls";
 import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
+  givenIHaveSignedIn,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
   whenIType,
@@ -10,6 +11,7 @@ import {
 describe("Given I have submitted invalid data to a registration form,", () => {
   describe("when I refresh the page,", () => {
     it("I can still see my invalid data", () => {
+      givenIHaveSignedIn();
       givenIHaveACookieSetAndIVisit(PageURLs.checkBeaconDetails);
       whenIType("ACME Inc.", "#manufacturer");
       whenIType("Excelsior", "#model");

--- a/cypress/integration/individual-pages/purpose.spec.ts
+++ b/cypress/integration/individual-pages/purpose.spec.ts
@@ -1,6 +1,7 @@
 import { asAnAviationBeaconOwner } from "../common/i-can-enter-beacon-information.spec";
 import {
   andIHaveEnteredNoInformation,
+  givenIHaveSignedIn,
   requiredFieldErrorMessage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenMyFocusMovesTo,
@@ -10,6 +11,7 @@ import {
 
 describe("As a beacon owner, I want to submit the purpose for my beacon", () => {
   it("displays an error if no beacon use purpose is selected", () => {
+    givenIHaveSignedIn();
     asAnAviationBeaconOwner();
     andIHaveEnteredNoInformation();
     whenIClickContinue();

--- a/cypress/integration/individual-pages/vesselCommunications.spec.ts
+++ b/cypress/integration/individual-pages/vesselCommunications.spec.ts
@@ -2,6 +2,7 @@ import {
   andIClickContinue,
   givenIHaveACookieSetAndIVisit,
   givenIHaveSelected,
+  givenIHaveSignedIn,
   iCanClickTheBackLinkToGoToPreviousPage,
   thenIShouldSeeAnErrorMessageThatContains,
   thenIShouldSeeAnErrorSummaryLinkThatContains,
@@ -26,6 +27,7 @@ describe("As a beacon owner and maritime pleasure vessel user", () => {
   const otherCommunicationInputSelector = "#otherCommunicationInput";
 
   beforeEach(() => {
+    givenIHaveSignedIn();
     givenIHaveACookieSetAndIVisit(pageUrl);
   });
 

--- a/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
+++ b/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
@@ -1,0 +1,9 @@
+import { givenIDoNotHaveAValidSession } from "../common/selectors-and-assertions.spec";
+
+describe("Your beacon registry account", () => {
+  it("Redirects the user to the sign up or sign in page if the user does not have a valid session", () => {
+    givenIDoNotHaveAValidSession();
+    cy.visit("/account/your-beacon-registry-account");
+    cy.url().should("eq", "http://localhost:3000/account/sign-up-or-sign-in");
+  });
+});

--- a/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
+++ b/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
@@ -1,9 +1,9 @@
 import { PageURLs } from "../../../src/lib/urls";
-import { givenIDoNotHaveAValidSession } from "../common/selectors-and-assertions.spec";
+import { givenIHaveNotSignedIn } from "../common/selectors-and-assertions.spec";
 
 describe("Your beacon registry account", () => {
   it("Redirects the user to the unauthenticated page if the user does not have a valid session", () => {
-    givenIDoNotHaveAValidSession();
+    givenIHaveNotSignedIn();
     cy.visit("/account/your-beacon-registry-account");
     cy.url().should("contain", PageURLs.unauthenticated);
   });

--- a/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
+++ b/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
@@ -5,6 +5,6 @@ describe("Your beacon registry account", () => {
   it("Redirects the user to the sign up or sign in page if the user does not have a valid session", () => {
     givenIDoNotHaveAValidSession();
     cy.visit("/account/your-beacon-registry-account");
-    cy.url().should("contain", PageURLs.signUpOrSignIn);
+    cy.url().should("contain", PageURLs.unauthenticated);
   });
 });

--- a/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
+++ b/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
@@ -1,9 +1,10 @@
+import { PageURLs } from "../../../src/lib/urls";
 import { givenIDoNotHaveAValidSession } from "../common/selectors-and-assertions.spec";
 
 describe("Your beacon registry account", () => {
   it("Redirects the user to the sign up or sign in page if the user does not have a valid session", () => {
     givenIDoNotHaveAValidSession();
     cy.visit("/account/your-beacon-registry-account");
-    cy.url().should("eq", "http://localhost:3000/account/sign-up-or-sign-in");
+    cy.url().should("contain", PageURLs.signUpOrSignIn);
   });
 });

--- a/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
+++ b/cypress/integration/individual-pages/yourBeaconRegistryAccount.spec.ts
@@ -2,7 +2,7 @@ import { PageURLs } from "../../../src/lib/urls";
 import { givenIDoNotHaveAValidSession } from "../common/selectors-and-assertions.spec";
 
 describe("Your beacon registry account", () => {
-  it("Redirects the user to the sign up or sign in page if the user does not have a valid session", () => {
+  it("Redirects the user to the unauthenticated page if the user does not have a valid session", () => {
     givenIDoNotHaveAValidSession();
     cy.visit("/account/your-beacon-registry-account");
     cy.url().should("contain", PageURLs.unauthenticated);

--- a/cypress/integration/single-beacon-owner/i-can-check-my-answers-optionals-dash.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-check-my-answers-optionals-dash.spec.ts
@@ -18,10 +18,14 @@ import {
   givenIHaveEnteredMyRequiredMaritimeUse,
   iCanSeeMyRequiredMaritimeUse,
 } from "../common/i-can-enter-use-information/maritime.spec";
-import { thenTheUrlShouldContain } from "../common/selectors-and-assertions.spec";
+import {
+  givenIHaveSignedIn,
+  thenTheUrlShouldContain,
+} from "../common/selectors-and-assertions.spec";
 
 describe("As a beacon owner who enters all required fields,", () => {
   it("I check my answers and the optional data is marked as dash", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyRequiredBeaconDetails();
     givenIHaveEnteredMyRequiredMaritimeUse(Purpose.PLEASURE);
     andIHaveNoFurtherUses();

--- a/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
@@ -57,6 +57,7 @@ import {
 } from "../common/i-can-enter-use-information/maritime.spec";
 import {
   givenIAmAt,
+  givenIHaveSignedIn,
   iAmAt,
   iCanSeeAPageHeadingThatContains,
   iCanSeeASectionHeadingThatContains,
@@ -66,6 +67,7 @@ import {
 
 describe("As a single beacon owner with many uses", () => {
   it("I can register my beacon for a land, maritime pleasure, and aviation pleasure use", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     iCanSeeAPageHeadingThatContains("main use");
     givenIHaveEnteredMyLandUse();

--- a/cypress/integration/single-beacon-owner/i-can-register-a-land-beacon.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-land-beacon.spec.ts
@@ -35,6 +35,7 @@ import {
 } from "../common/i-can-enter-use-information/land.spec";
 import {
   andIClickContinue,
+  givenIHaveSignedIn,
   iAmAt,
   thenTheUrlShouldContain,
   whenIClickBack,
@@ -42,6 +43,7 @@ import {
 
 describe("As a land beacon owner", () => {
   it("I can register my beacon", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyLandUse();
     iCanSeeMyLandUse();

--- a/cypress/integration/single-beacon-owner/i-can-register-a-maritime-beacon.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-maritime-beacon.spec.ts
@@ -19,10 +19,14 @@ import {
   iCanGoBackAndEditMyMaritimeUse,
   iCanSeeMyMaritimeUse,
 } from "../common/i-can-enter-use-information/maritime.spec";
-import { thenTheUrlShouldContain } from "../common/selectors-and-assertions.spec";
+import {
+  givenIHaveSignedIn,
+  thenTheUrlShouldContain,
+} from "../common/selectors-and-assertions.spec";
 
 describe("As a maritime beacon owner,", () => {
   it("I can register my beacon for pleasure purposes", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyMaritimeUse(Purpose.PLEASURE);
     iCanSeeMyMaritimeUse(Purpose.PLEASURE);
@@ -43,6 +47,7 @@ describe("As a maritime beacon owner,", () => {
   });
 
   it("I can register my beacon for commercial purposes", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyMaritimeUse(Purpose.COMMERCIAL);
     iCanSeeMyMaritimeUse(Purpose.COMMERCIAL);

--- a/cypress/integration/single-beacon-owner/i-can-register-an-aviation-beacon.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-an-aviation-beacon.spec.ts
@@ -20,10 +20,14 @@ import {
   iCanSeeMySingleAviationUse,
 } from "../common/i-can-enter-use-information/aviation.spec";
 import { andIHaveNoFurtherUses } from "../common/i-can-enter-use-information/generic.spec";
-import { thenTheUrlShouldContain } from "../common/selectors-and-assertions.spec";
+import {
+  givenIHaveSignedIn,
+  thenTheUrlShouldContain,
+} from "../common/selectors-and-assertions.spec";
 
 describe("As an aviation beacon owner,", () => {
   it("I can register my beacon for pleasure purposes", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyAviationUse(Purpose.PLEASURE);
     iCanSeeMyAviationUse(Purpose.PLEASURE);
@@ -44,6 +48,7 @@ describe("As an aviation beacon owner,", () => {
   });
 
   it("I can register my beacon for commercial purposes", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyAviationUse(Purpose.COMMERCIAL);
     iCanSeeMyAviationUse(Purpose.COMMERCIAL);

--- a/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-remove-a-use.spec.ts
@@ -18,11 +18,13 @@ import {
 } from "../common/i-can-enter-use-information/maritime.spec";
 import {
   andIClickTheButtonContaining,
+  givenIHaveSignedIn,
   whenIClickTheButtonContaining,
 } from "../common/selectors-and-assertions.spec";
 
 describe("As a beacon owner with several uses", () => {
   it("I can safely remove a use from my draft registration", () => {
+    givenIHaveSignedIn();
     givenIHaveEnteredMyBeaconDetails();
     givenIHaveEnteredMyLandUse();
     andIHaveAnotherUse();

--- a/src/lib/appContainer.ts
+++ b/src/lib/appContainer.ts
@@ -83,6 +83,9 @@ export const getAppContainer = (overrides?: IAppContainer): IAppContainer => {
     get NextAuthUserSessionGateway() {
       return new NextAuthUserSessionGateway();
     },
+    get sessionGateway() {
+      return new NextAuthUserSessionGateway();
+    },
     get basicAuthGateway() {
       return new BasicAuthGateway();
     },

--- a/src/lib/appContainer.ts
+++ b/src/lib/appContainer.ts
@@ -80,9 +80,6 @@ export const getAppContainer = (overrides?: IAppContainer): IAppContainer => {
     get draftRegistrationGateway() {
       return new RedisDraftRegistrationGateway();
     },
-    get NextAuthUserSessionGateway() {
-      return new NextAuthUserSessionGateway();
-    },
     get sessionGateway() {
       return new NextAuthUserSessionGateway();
     },

--- a/src/lib/form/formManagers/accountDetailsFormManager.ts
+++ b/src/lib/form/formManagers/accountDetailsFormManager.ts
@@ -1,9 +1,9 @@
-import { FormSubmission } from "../../../presenters/formSubmission";
+import { FormManagerFactory } from "../../handlePageRequest";
 import { FieldManager } from "../FieldManager";
 import { FormManager } from "../FormManager";
 import { Validators } from "../Validators";
 
-export const accountDetailsFormManager = ({
+export const accountDetailsFormManager: FormManagerFactory = ({
   fullName,
   telephoneNumber,
   addressLine1,
@@ -12,7 +12,7 @@ export const accountDetailsFormManager = ({
   county,
   postcode,
   email,
-}: FormSubmission): FormManager => {
+}) => {
   return new FormManager({
     fullName: new FieldManager(fullName, [
       Validators.required("Full name is a required field"),

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -30,6 +30,7 @@ export enum PageURLs {
   deleteRegistrationSuccess = "/manage-my-registrations/delete/success",
   deleteRegistrationFailure = "/manage-my-registrations/delete/failure",
   serverError = "/500",
+  unauthenticated = "/unauthenticated",
 }
 
 export enum ActionURLs {

--- a/src/pages/account/update-account.tsx
+++ b/src/pages/account/update-account.tsx
@@ -22,6 +22,7 @@ import { withSession } from "../../lib/middleware/withSession";
 import { redirectUserTo } from "../../lib/redirectUserTo";
 import { PageURLs } from "../../lib/urls";
 import { diffObjValues } from "../../lib/utils";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 
 export interface UpdateAccountPageProps {
   form: FormJSON;
@@ -159,6 +160,11 @@ const userDidSubmitForm = (
 
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {
+    const rule = new IfUserDoesNotHaveValidSession(context);
+    if (await rule.condition()) {
+      return rule.action();
+    }
+
     const { parseFormDataAs, updateAccountHolder, getOrCreateAccountHolder } =
       context.container;
 

--- a/src/pages/account/your-beacon-registry-account.tsx
+++ b/src/pages/account/your-beacon-registry-account.tsx
@@ -298,7 +298,7 @@ class IfUserIsSignedInAndHasValidAccountDetails implements Rule {
   public async action(): Promise<GetServerSidePropsResult<any>> {
     const accountHolderDetails = await this.getAccountHolderDetails();
     const beacons = await this.getBeacons(accountHolderDetails.id);
-    this.createDraftRegistrationIfNoneForUser();
+    await this.createDraftRegistrationIfNoneForUser();
 
     return {
       props: {

--- a/src/pages/manage-my-registrations/delete/index.tsx
+++ b/src/pages/manage-my-registrations/delete/index.tsx
@@ -20,6 +20,7 @@ import { BeaconsPageRouter } from "../../../router/BeaconsPageRouter";
 import { GivenUserIsDeletingARegistration_WhenUserDoesNotProvideAReason_ThenShowErrorMessage } from "../../../router/rules/GivenUserIsDeletingARegistration_WhenUserDoesNotProvideAReason_ThenShowErrorMessage";
 import { GivenUserIsDeletingARegistration_WhenUserProvidesAReason_ThenDeleteTheRegistration } from "../../../router/rules/GivenUserIsDeletingARegistration_WhenUserProvidesAReason_ThenDeleteTheRegistration";
 import { GivenUserIsDeletingARegistration_WhenUserViewsPage_ThenDisplayPage } from "../../../router/rules/GivenUserIsDeletingARegistration_WhenUserViewsPage_ThenDisplayPage";
+import { IfUserDoesNotHaveValidSession } from "../../../router/rules/IfUserDoesNotHaveValidSession";
 
 export interface DeleteRegistrationProps {
   form: FormJSON;
@@ -154,6 +155,7 @@ export const DeleteRegistration: FunctionComponent<DeleteRegistrationProps> = ({
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new GivenUserIsDeletingARegistration_WhenUserViewsPage_ThenDisplayPage(
         context,
         validationRules

--- a/src/pages/register-a-beacon/about-beacon-owner.tsx
+++ b/src/pages/register-a-beacon/about-beacon-owner.tsx
@@ -14,6 +14,7 @@ import { PageURLs, queryParams } from "../../lib/urls";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { FormSubmission } from "../../presenters/formSubmission";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
 import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserSubmittedValidRegistrationForm";
@@ -126,6 +127,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPageUrl = PageURLs.beaconOwnerAddress;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<AboutBeaconOwnerForm>(
         context,

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -23,6 +23,7 @@ import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationF
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -231,6 +232,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.aircraftCommunications;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserViewedRegistrationForm<AboutTheAircraftForm>(

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -19,6 +19,7 @@ import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationF
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -245,6 +246,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.vesselCommunications;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<AboutTheVesselForm>(

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -25,6 +25,7 @@ import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationF
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -567,6 +568,7 @@ const LandOptions: FunctionComponent<OptionsProps> = ({
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<ActivityForm>(

--- a/src/pages/register-a-beacon/additional-beacon-use.tsx
+++ b/src/pages/register-a-beacon/additional-beacon-use.tsx
@@ -13,6 +13,7 @@ import { formSubmissionCookieId } from "../../lib/types";
 import { ActionURLs, PageURLs, queryParams } from "../../lib/urls";
 import { prettyUseName } from "../../lib/writingStyle";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserViewedPage } from "../../router/rules/IfUserViewedPage";
@@ -121,6 +122,7 @@ const confirmBeforeDelete = (use: DraftBeaconUse, index: number) =>
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedPage(context, props(context)),

--- a/src/pages/register-a-beacon/aircraft-communications.tsx
+++ b/src/pages/register-a-beacon/aircraft-communications.tsx
@@ -18,6 +18,7 @@ import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -147,6 +148,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.moreDetails;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<AircraftCommunicationsForm>(

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -15,6 +15,7 @@ import { withSession } from "../../lib/middleware/withSession";
 import { redirectUserTo } from "../../lib/redirectUserTo";
 import { formSubmissionCookieId } from "../../lib/types";
 import { PageURLs } from "../../lib/urls";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { ISubmitRegistrationResult } from "../../useCases/submitRegistration";
 
 interface ApplicationCompleteProps {
@@ -78,6 +79,11 @@ const ApplicationCompleteWhatNext: FunctionComponent = (): JSX.Element => (
 
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {
+    const rule = new IfUserDoesNotHaveValidSession(context);
+
+    if (await rule.condition()) {
+      return rule.action();
+    }
     /* Retrieve injected use case(s) */
     const { getDraftRegistration, submitRegistration, getAccountHolderId } =
       context.container;

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -25,6 +25,7 @@ import { padNumberWithLeadingZeros } from "../../lib/writingStyle";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { FormSubmission } from "../../presenters/formSubmission";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
 import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserSubmittedValidRegistrationForm";
@@ -204,6 +205,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPageUrl = PageURLs.environment;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm(context, validationRules, mapper),
       new IfUserSubmittedInvalidRegistrationForm(

--- a/src/pages/register-a-beacon/beacon-owner-address.tsx
+++ b/src/pages/register-a-beacon/beacon-owner-address.tsx
@@ -23,6 +23,7 @@ import { withSession } from "../../lib/middleware/withSession";
 import { PageURLs } from "../../lib/urls";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
 import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserSubmittedValidRegistrationForm";
@@ -144,6 +145,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPageUrl = PageURLs.emergencyContact;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<BeaconOwnerAddressForm>(
         context,

--- a/src/pages/register-a-beacon/beacon-use.tsx
+++ b/src/pages/register-a-beacon/beacon-use.tsx
@@ -17,6 +17,7 @@ import { ordinal } from "../../lib/writingStyle";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -106,6 +107,7 @@ const BeaconUse: FunctionComponent<DraftBeaconUsePageProps> = ({
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<BeaconUseForm>(

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -16,6 +16,7 @@ import { PageURLs } from "../../lib/urls";
 import { toUpperCase } from "../../lib/writingStyle";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
 import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserSubmittedValidRegistrationForm";
@@ -116,6 +117,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPageUrl = PageURLs.beaconInformation;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm(context, validationRules, mapper),
       new IfUserSubmittedInvalidRegistrationForm(

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../lib/writingStyle";
 import { FormSubmission } from "../../presenters/formSubmission";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserViewedPage } from "../../router/rules/IfUserViewedPage";
 
@@ -587,6 +588,7 @@ const SendYourApplication: FunctionComponent = (): JSX.Element => (
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedPage(context, props(context)),
     ]).execute();

--- a/src/pages/register-a-beacon/emergency-contact.tsx
+++ b/src/pages/register-a-beacon/emergency-contact.tsx
@@ -26,6 +26,7 @@ import { PageURLs } from "../../lib/urls";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { FormSubmission } from "../../presenters/formSubmission";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
 import { IfUserSubmittedValidRegistrationForm } from "../../router/rules/IfUserSubmittedValidRegistrationForm";
@@ -192,6 +193,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPageUrl = PageURLs.checkYourAnswers;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<EmergencyContactForm>(
         context,

--- a/src/pages/register-a-beacon/land-communications.tsx
+++ b/src/pages/register-a-beacon/land-communications.tsx
@@ -19,6 +19,7 @@ import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationF
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -168,6 +169,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.moreDetails;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<LandCommunicationsForm>(

--- a/src/pages/register-a-beacon/more-details.tsx
+++ b/src/pages/register-a-beacon/more-details.tsx
@@ -18,6 +18,7 @@ import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationF
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -113,6 +114,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.additionalUse;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<MoreDetailsForm>(

--- a/src/pages/register-a-beacon/purpose.tsx
+++ b/src/pages/register-a-beacon/purpose.tsx
@@ -17,6 +17,7 @@ import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { FormSubmission } from "../../presenters/formSubmission";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -80,6 +81,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.activity;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<PurposeForm>(

--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -18,6 +18,7 @@ import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
 import { BeaconsPageRouter } from "../../router/BeaconsPageRouter";
+import { IfUserDoesNotHaveValidSession } from "../../router/rules/IfUserDoesNotHaveValidSession";
 import { IfUserHasNotSpecifiedAUse } from "../../router/rules/IfUserHasNotSpecifiedAUse";
 import { IfUserHasNotStartedEditingADraftRegistration } from "../../router/rules/IfUserHasNotStartedEditingADraftRegistration";
 import { IfUserSubmittedInvalidRegistrationForm } from "../../router/rules/IfUserSubmittedInvalidRegistrationForm";
@@ -221,6 +222,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
     const nextPage = PageURLs.moreDetails;
 
     return await new BeaconsPageRouter([
+      new IfUserDoesNotHaveValidSession(context),
       new IfUserHasNotSpecifiedAUse(context),
       new IfUserHasNotStartedEditingADraftRegistration(context),
       new IfUserViewedRegistrationForm<VesselCommunicationsForm>(

--- a/src/pages/unauthenticated.tsx
+++ b/src/pages/unauthenticated.tsx
@@ -1,0 +1,42 @@
+import React, { FunctionComponent } from "react";
+import { LinkButton } from "../components/Button";
+import { Grid } from "../components/Grid";
+import { Layout } from "../components/Layout";
+import { BeaconRegistryContactInfo } from "../components/Mca";
+import {
+  GovUKBody,
+  PageHeading,
+  SectionHeading,
+} from "../components/Typography";
+import { PageURLs } from "../lib/urls";
+
+const Unauthenticated: FunctionComponent = (): JSX.Element => {
+  const pageHeading = "You must be signed in to access this page";
+
+  return (
+    <Layout title={pageHeading} showCookieBanner={false}>
+      <Grid
+        mainContent={
+          <>
+            <PageHeading>{pageHeading}</PageHeading>
+            <GovUKBody>
+              To access this service, you must return to the service start page
+              and start again.
+            </GovUKBody>
+            <GovUKBody>
+              Make sure that your browser can accept cookies.
+            </GovUKBody>
+            <LinkButton
+              buttonText="Go to service start page"
+              href={PageURLs.start}
+            />
+            <SectionHeading>Contact the UK Beacon Registry</SectionHeading>
+            <BeaconRegistryContactInfo />
+          </>
+        }
+      />
+    </Layout>
+  );
+};
+
+export default Unauthenticated;

--- a/src/router/rules/IfUserDoesNotHaveValidAccountDetails.ts
+++ b/src/router/rules/IfUserDoesNotHaveValidAccountDetails.ts
@@ -13,7 +13,7 @@ export class IfUserDoesNotHaveValidAccountDetails implements Rule {
   ) {}
 
   public async condition(): Promise<boolean> {
-    const accountHolderDetails = this.getAccountHolderDetails();
+    const accountHolderDetails = await this.getAccountHolderDetails();
 
     return this.validationRules(accountHolderDetails).asDirty().hasErrors();
   }

--- a/src/router/rules/IfUserDoesNotHaveValidAccountDetails.ts
+++ b/src/router/rules/IfUserDoesNotHaveValidAccountDetails.ts
@@ -1,0 +1,30 @@
+import { GetServerSidePropsResult } from "next";
+import { AccountHolder } from "../../entities/AccountHolder";
+import { FormManagerFactory } from "../../lib/handlePageRequest";
+import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
+import { redirectUserTo } from "../../lib/redirectUserTo";
+import { PageURLs } from "../../lib/urls";
+import { Rule } from "./Rule";
+
+export class IfUserDoesNotHaveValidAccountDetails implements Rule {
+  constructor(
+    private readonly context: BeaconsGetServerSidePropsContext,
+    private readonly validationRules: FormManagerFactory
+  ) {}
+
+  public async condition(): Promise<boolean> {
+    const accountHolderDetails = this.getAccountHolderDetails();
+
+    return this.validationRules(accountHolderDetails).asDirty().hasErrors();
+  }
+
+  private async getAccountHolderDetails(): Promise<AccountHolder> {
+    const { getOrCreateAccountHolder } = this.context.container;
+
+    return getOrCreateAccountHolder(this.context.session);
+  }
+
+  public async action(): Promise<GetServerSidePropsResult<any>> {
+    return redirectUserTo(PageURLs.updateAccount);
+  }
+}

--- a/src/router/rules/IfUserDoesNotHaveValidSession.ts
+++ b/src/router/rules/IfUserDoesNotHaveValidSession.ts
@@ -16,6 +16,6 @@ export class IfUserDoesNotHaveValidSession implements Rule {
   }
 
   public async action(): Promise<GetServerSidePropsResult<any>> {
-    return redirectUserTo(PageURLs.signUpOrSignIn);
+    return redirectUserTo(PageURLs.unauthenticated);
   }
 }

--- a/src/router/rules/IfUserDoesNotHaveValidSession.ts
+++ b/src/router/rules/IfUserDoesNotHaveValidSession.ts
@@ -1,0 +1,21 @@
+import { GetServerSidePropsResult } from "next";
+import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
+import { redirectUserTo } from "../../lib/redirectUserTo";
+import { PageURLs } from "../../lib/urls";
+import { Rule } from "./Rule";
+
+export class IfUserDoesNotHaveValidSession implements Rule {
+  constructor(private readonly context: BeaconsGetServerSidePropsContext) {}
+
+  public async condition(): Promise<boolean> {
+    const session = await this.context.container.sessionGateway.getSession(
+      this.context
+    );
+
+    return session == null;
+  }
+
+  public async action(): Promise<GetServerSidePropsResult<any>> {
+    return redirectUserTo(PageURLs.signUpOrSignIn);
+  }
+}

--- a/test/pages/account/update-account.test.tsx
+++ b/test/pages/account/update-account.test.tsx
@@ -31,6 +31,12 @@ describe("UpdateAccount", () => {
       })
     );
 
+    const mockSessionGateway = {
+      getSession: jest
+        .fn()
+        .mockReturnValue({ user: { authId: "test-auth-id" } }),
+    };
+
     const mockAuthGateway: AuthGateway = {
       getAccessToken: jest.fn().mockResolvedValue(v4()),
     };
@@ -49,6 +55,7 @@ describe("UpdateAccount", () => {
       const mockRequest: any = { method: "GET" };
       const containerMocks: Partial<IAppContainer> = {
         accountHolderGateway: accountHolderApiGateway,
+        sessionGateway: mockSessionGateway,
       };
       const context: Partial<BeaconsGetServerSidePropsContext> = {
         container: getAppContainer(containerMocks as IAppContainer),
@@ -87,6 +94,7 @@ describe("UpdateAccount", () => {
           county: "new county",
           postcode: "invalid postcode",
         }),
+        sessionGateway: mockSessionGateway,
       };
       const context: Partial<BeaconsGetServerSidePropsContext> = {
         container: getAppContainer(containerMocks as IAppContainer),
@@ -127,6 +135,7 @@ describe("UpdateAccount", () => {
           county: "new county",
           postcode: "bs7 9lm",
         }), // a valid postcode this time
+        sessionGateway: mockSessionGateway,
       };
 
       const context: Partial<BeaconsGetServerSidePropsContext> = {
@@ -161,6 +170,7 @@ describe("UpdateAccount", () => {
           county: "", //changed
           postcode: "TS1 2AB", //changed
         }),
+        sessionGateway: mockSessionGateway,
       };
 
       const context: Partial<BeaconsGetServerSidePropsContext> = {

--- a/test/pages/account/your-beacon-registry-account.test.tsx
+++ b/test/pages/account/your-beacon-registry-account.test.tsx
@@ -20,11 +20,15 @@ describe("YourBeaconRegistryAccount", () => {
   const mockAuthGateway: AuthGateway = {
     getAccessToken: jest.fn().mockResolvedValue(v4()),
   };
+  const mockSessionGateway = {
+    getSession: jest.fn().mockReturnValue({ user: { authId: "a-session-id" } }),
+  };
   const mocks: Partial<IAppContainer> = {
     accountHolderGateway: new BeaconsApiAccountHolderGateway(
       process.env.API_URL,
       mockAuthGateway
     ),
+    sessionGateway: mockSessionGateway as any,
   };
 
   describe("GetServerSideProps for user with full account details", () => {
@@ -58,6 +62,7 @@ describe("YourBeaconRegistryAccount", () => {
           cookies: {
             [formSubmissionCookieId]: "set",
           },
+          method: "GET",
         } as any,
       };
 
@@ -101,6 +106,7 @@ describe("YourBeaconRegistryAccount", () => {
           cookies: {
             [formSubmissionCookieId]: "set",
           },
+          method: "GET",
         } as any,
       };
 

--- a/test/pages/register-a-beacon/additional-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/additional-beacon-use.test.tsx
@@ -103,6 +103,11 @@ describe("AdditionalBeaconUse page", () => {
 
   describe("getServerSideProps()", () => {
     it("given a non-existent currentUseIndex, throws an error", () => {
+      const mockSessionGateway = {
+        getSession: jest
+          .fn()
+          .mockReturnValue({ user: { authId: "a-session-id" } }),
+      };
       const mockRegistration = {
         getRegistration: jest
           .fn()
@@ -115,6 +120,7 @@ describe("AdditionalBeaconUse page", () => {
         },
         container: {
           getCachedRegistration: jest.fn().mockResolvedValue(mockRegistration),
+          sessionGateway: mockSessionGateway,
         },
         req: {
           cookies: {

--- a/test/pages/register-a-beacon/application-complete.test.tsx
+++ b/test/pages/register-a-beacon/application-complete.test.tsx
@@ -22,6 +22,12 @@ describe("ApplicationCompletePage", () => {
       uses: [],
     };
 
+    const mockSessionGateway = {
+      getSession: jest
+        .fn()
+        .mockReturnValue({ user: { authId: "test-auth-id" } }),
+    };
+
     let mockContainer: Partial<IAppContainer>;
 
     const mockSubmitRegistration = jest.fn().mockResolvedValue({
@@ -37,6 +43,7 @@ describe("ApplicationCompletePage", () => {
         getDraftRegistration: jest
           .fn()
           .mockResolvedValue(mockDraftRegistration),
+        sessionGateway: mockSessionGateway,
       };
     });
 

--- a/test/router/rules/IfUserDoesNotHaveValidAccountDetails.test.ts
+++ b/test/router/rules/IfUserDoesNotHaveValidAccountDetails.test.ts
@@ -1,0 +1,65 @@
+import { PageURLs } from "../../../src/lib/urls";
+import { IfUserDoesNotHaveValidAccountDetails } from "../../../src/router/rules/IfUserDoesNotHaveValidAccountDetails";
+
+describe("IfUserDoesNotHaveValidAccountDetails", () => {
+  it("should route the user to the update account page if the account details are not valid", async () => {
+    const mockGetOrCreateAccountHolder = jest.fn().mockReturnValueOnce({});
+    const mockHasErrors = jest.fn().mockReturnValueOnce(true);
+    const mockAsDirty = jest
+      .fn()
+      .mockImplementation(() => ({ hasErrors: mockHasErrors }));
+    const mockAccountDetailsFormManager = jest
+      .fn()
+      .mockImplementation(() => ({ asDirty: mockAsDirty }));
+
+    const context = {
+      session: {},
+      container: {
+        getOrCreateAccountHolder: mockGetOrCreateAccountHolder,
+      },
+    };
+
+    const rule = new IfUserDoesNotHaveValidAccountDetails(
+      context as any,
+      mockAccountDetailsFormManager
+    );
+
+    const condition = await rule.condition();
+    expect(condition).toBe(true);
+    expect(mockAccountDetailsFormManager).toHaveBeenCalledTimes(1);
+
+    const result = await rule.action();
+    expect(result).toStrictEqual({
+      redirect: {
+        statusCode: 303,
+        destination: PageURLs.updateAccount,
+      },
+    });
+  });
+
+  it("should not trigger if the user has a valid session", async () => {
+    const mockGetOrCreateAccountHolder = jest.fn().mockReturnValueOnce({});
+    const mockHasErrors = jest.fn().mockReturnValueOnce(false);
+    const mockAsDirty = jest
+      .fn()
+      .mockImplementation(() => ({ hasErrors: mockHasErrors }));
+    const mockAccountDetailsFormManager = jest
+      .fn()
+      .mockImplementation(() => ({ asDirty: mockAsDirty }));
+
+    const context = {
+      session: {},
+      container: {
+        getOrCreateAccountHolder: mockGetOrCreateAccountHolder,
+      },
+    };
+
+    const rule = new IfUserDoesNotHaveValidAccountDetails(
+      context as any,
+      mockAccountDetailsFormManager
+    );
+
+    const condition = await rule.condition();
+    expect(condition).toBe(false);
+  });
+});

--- a/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
+++ b/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
@@ -1,0 +1,62 @@
+import { BeaconsSession } from "../../../src/gateways/NextAuthUserSessionGateway";
+import { PageURLs } from "../../../src/lib/urls";
+import { IfUserDoesNotHaveValidSession } from "../../../src/router/rules/IfUserDoesNotHaveValidSession";
+
+describe("IfUserDoesNotHaveValidSession", () => {
+  it("routes the user to the sign up or sign in page if the session is not valid", async () => {
+    const mockGetSession = jest.fn();
+    mockGetSession.mockReturnValueOnce(null);
+
+    const context = {
+      container: {
+        sessionGateway: {
+          getSession: mockGetSession,
+        },
+      },
+    };
+
+    const rule = new IfUserDoesNotHaveValidSession(context as any);
+
+    const condition = await rule.condition();
+    expect(condition).toBe(true);
+
+    const result = await rule.action();
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual({
+      redirect: {
+        statusCode: 303,
+        destination: PageURLs.signUpOrSignIn,
+      },
+    });
+  });
+
+  it("does not trigger if the user has a valid session", async () => {
+    const mockGetSession = jest.fn();
+    const session: BeaconsSession = {
+      user: {
+        authId: "foo",
+        name: "bar",
+        email: "baz",
+        image: "qux",
+      },
+      expires: "quux",
+    };
+    mockGetSession.mockReturnValueOnce(session);
+
+    const context = {
+      container: {
+        sessionGateway: {
+          getSession: mockGetSession,
+        },
+      },
+    };
+
+    const rule = new IfUserDoesNotHaveValidSession(context as any);
+
+    const condition = await rule.condition();
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    expect(condition).toBe(false);
+  });
+});

--- a/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
+++ b/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
@@ -26,7 +26,7 @@ describe("IfUserDoesNotHaveValidSession", () => {
     expect(result).toStrictEqual({
       redirect: {
         statusCode: 303,
-        destination: PageURLs.signUpOrSignIn,
+        destination: PageURLs.unauthenticated,
       },
     });
   });

--- a/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
+++ b/test/router/rules/IfUserDoesNotHaveValidSession.test.ts
@@ -3,7 +3,7 @@ import { PageURLs } from "../../../src/lib/urls";
 import { IfUserDoesNotHaveValidSession } from "../../../src/router/rules/IfUserDoesNotHaveValidSession";
 
 describe("IfUserDoesNotHaveValidSession", () => {
-  it("routes the user to the sign up or sign in page if the session is not valid", async () => {
+  it("should route the user to the sign up or sign in page if the session is not valid", async () => {
     const mockGetSession = jest.fn();
     mockGetSession.mockReturnValueOnce(null);
 
@@ -31,7 +31,7 @@ describe("IfUserDoesNotHaveValidSession", () => {
     });
   });
 
-  it("does not trigger if the user has a valid session", async () => {
+  it("should not trigger if the user has a valid session", async () => {
     const mockGetSession = jest.fn();
     const session: BeaconsSession = {
       user: {


### PR DESCRIPTION
## Context

Many of the pages in the service should require a logged in state in order to be accessed. This PR lays the groundwork for that requirement by adding rule `IfUserDoesNotHaveValidSession` for `BeaconsPageRouter` that will redirects the user to the page `/unauthenticated` if the user tries to navigate to a protected page without a valid session. The PR applies the new rule to the page `/account/your-beacon-registry-account` and should now be applied to other pages that require it.

## Changes in this pull request

- Added new rule `IfUserDoesNotHaveValidSession`
- Added new rule `IfUserDoesNotHaveValidAccountDetails`
- Updated page `/account/your-beacon-registry-account` to use `BeaconsPageRouter`
- Added page `/unauthenticated` for redirecting unauthenticated requests to

## Guidance to review

Need feedback on page `/unauthenticated` relating to naming of page and content of page.

## Link to Trello card

https://trello.com/c/mynRdNID/797-implementation-lockdown-all-pages-that-should-require-a-logged-in-state
