### PR TITLE
append useIndex onto nextPage in draft beacon use

### DIFF
--- a/cypress/common/i-can-enter-use-information/generic.spec.ts
+++ b/cypress/common/i-can-enter-use-information/generic.spec.ts
@@ -39,14 +39,14 @@ export const iCanEditMyNUses = (n: number): void => {
   iCanSeeAButtonContaining("Add another");
 };
 
-export const whenIGoToEditTheUseNumber = (useNumber: number) => {
+export const whenIGoToEditTheUseNumber = (useNumber: number): void => {
   iHaveClickedOnAGivenLink(
     `${CreateRegistrationPageURLs.environment}?useIndex=${useNumber}`
   );
   whenIClickContinue();
 };
 
-export const iAmOnTheLandBranchForUseNumber = (useNumber: number) => {
+export const iAmOnTheLandBranchForUseNumber = (useNumber: number): void => {
   thenTheUrlShouldContain(
     `${CreateRegistrationPageURLs.activity}?useIndex=${useNumber}`
   );
@@ -54,7 +54,7 @@ export const iAmOnTheLandBranchForUseNumber = (useNumber: number) => {
 
 export const iAmOnTheMaritimeOrAviationBranchForUseNumber = (
   useNumber: number
-) => {
+): void => {
   thenTheUrlShouldContain(
     `${CreateRegistrationPageURLs.purpose}?useIndex=${useNumber}`
   );

--- a/cypress/common/i-can-enter-use-information/generic.spec.ts
+++ b/cypress/common/i-can-enter-use-information/generic.spec.ts
@@ -39,8 +39,23 @@ export const iCanEditMyNUses = (n: number): void => {
   iCanSeeAButtonContaining("Add another");
 };
 
-export const iAmEditingTheCorrectUse = (href1: string, href2: string): void => {
-  iHaveClickedOnAGivenLink(href1);
+export const whenIGoToEditTheUseNumber = (useNumber: number) => {
+  iHaveClickedOnAGivenLink(
+    `${CreateRegistrationPageURLs.environment}?useIndex=${useNumber}`
+  );
   whenIClickContinue();
-  thenTheUrlShouldContain(href2);
+};
+
+export const iAmOnTheLandBranchForUseNumber = (useNumber: number) => {
+  thenTheUrlShouldContain(
+    `${CreateRegistrationPageURLs.activity}?useIndex=${useNumber}`
+  );
+};
+
+export const iAmOnTheMaritimeOrAviationBranchForUseNumber = (
+  useNumber: number
+) => {
+  thenTheUrlShouldContain(
+    `${CreateRegistrationPageURLs.purpose}?useIndex=${useNumber}`
+  );
 };

--- a/cypress/common/i-can-enter-use-information/generic.spec.ts
+++ b/cypress/common/i-can-enter-use-information/generic.spec.ts
@@ -5,7 +5,9 @@ import {
   andIClickTheButtonContaining,
   iCanSeeAButtonContaining,
   iCanSeeNLinksContaining,
+  iHaveClickedOnAGivenLink,
   thenTheUrlShouldContain,
+  whenIClickContinue,
 } from "../selectors-and-assertions.spec";
 
 export const iCanEditMyEnvironment = (environment: Environment): void => {
@@ -35,4 +37,10 @@ export const iCanEditMyNUses = (n: number): void => {
   iCanSeeNLinksContaining(n, "Delete");
   iCanSeeAButtonContaining("Continue");
   iCanSeeAButtonContaining("Add another");
+};
+
+export const iAmEditingTheCorrectUse = (href1: string, href2: string): void => {
+  iHaveClickedOnAGivenLink(href1);
+  whenIClickContinue();
+  thenTheUrlShouldContain(href2);
 };

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -210,3 +210,6 @@ export const thenThereAreNoErrors = (): void => {
 export const iCanEditAFieldContaining = (value: string): void => {
   cy.get(`input[value="${value}"]`);
 };
+export const iHaveClickedOnAGivenLink = (href: string) => {
+  cy.get(`a[href]:contains(${href})`);
+};

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -211,5 +211,5 @@ export const iCanEditAFieldContaining = (value: string): void => {
   cy.get(`input[value="${value}"]`);
 };
 export const iHaveClickedOnAGivenLink = (href: string) => {
-  cy.get(`a[href]:contains(${href})`);
+  cy.get(`a[href="${href}"]`).click();
 };

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -210,6 +210,6 @@ export const thenThereAreNoErrors = (): void => {
 export const iCanEditAFieldContaining = (value: string): void => {
   cy.get(`input[value="${value}"]`);
 };
-export const iHaveClickedOnAGivenLink = (href: string) => {
+export const iHaveClickedOnAGivenLink = (href: string): void => {
   cy.get(`a[href="${href}"]`).click();
 };

--- a/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
@@ -10,19 +10,11 @@ import {
   givenIHaveEnteredMyBeaconDetails,
   iCanEditMyAdditionalBeaconInformation,
   iCanEditMyBeaconDetails,
-  iCanSeeMyAdditionalBeaconInformation,
-  iCanSeeMyBeaconDetails,
 } from "../../common/i-can-enter-beacon-information.spec";
 import {
-  givenIHaveEnteredMyAddressDetails,
-  givenIHaveEnteredMyEmergencyContactDetails,
-  givenIHaveEnteredMyPersonalDetails,
   iCanEditMyAddressDetails,
   iCanEditMyEmergencyContactDetails,
   iCanEditMyPersonalDetails,
-  iCanSeeMyAddressDetails,
-  iCanSeeMyEmergencyContactDetails,
-  iCanSeeMyPersonalDetails,
 } from "../../common/i-can-enter-owner-information.spec";
 import {
   givenIHaveEnteredMyAviationUse,
@@ -32,11 +24,10 @@ import {
   iCanEditMyAviationActivity,
   iCanEditMyAviationEnvironment,
   iCanEditMyAviationPurpose,
-  iCanSeeMyAviationUse,
 } from "../../common/i-can-enter-use-information/aviation.spec";
 import {
   andIHaveAnotherUse,
-  andIHaveNoFurtherUses,
+  iAmEditingTheCorrectUse,
   iCanEditMyEnvironment,
   iCanEditMyNUses,
 } from "../../common/i-can-enter-use-information/generic.spec";
@@ -46,7 +37,6 @@ import {
   iCanEditMyLandActivity,
   iCanEditMyLandCommunications,
   iCanEditMyLandEnvironment,
-  iCanSeeMyLandUse,
 } from "../../common/i-can-enter-use-information/land.spec";
 import {
   givenIHaveEnteredMyMaritimeUse,
@@ -56,15 +46,12 @@ import {
   iCanEditMyMaritimePurpose,
   iCanEditMyVesselCommunications,
   iCanEditMyVesselDetails,
-  iCanSeeMyMaritimeUse,
 } from "../../common/i-can-enter-use-information/maritime.spec";
 import {
   givenIHaveSignedIn,
   givenIHaveVisited,
   iCanSeeAPageHeadingThatContains,
-  iCanSeeASectionHeadingThatContains,
   iHaveVisited,
-  thenTheUrlShouldContain,
   whenIClickBack,
 } from "../../common/selectors-and-assertions.spec";
 
@@ -83,24 +70,39 @@ describe("As a single beacon owner with many uses", () => {
     iCanSeeAPageHeadingThatContains("third use");
     givenIHaveEnteredMyAviationUse(Purpose.PLEASURE);
     iCanEditMyNUses(3);
-    andIHaveNoFurtherUses();
+    iAmEditingTheCorrectUse(
+      "/register-a-beacon/beacon-use?useIndex=0",
+      "/register-a-beacon/activity?useIndex=0"
+    );
+    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
+    iAmEditingTheCorrectUse(
+      "/register-a-beacon/beacon-use?useIndex=1",
+      "/register-a-beacon/purpose?useIndex=1"
+    );
+    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
+    iAmEditingTheCorrectUse(
+      "/register-a-beacon/beacon-use?useIndex=2",
+      "/register-a-beacon/purpose?useIndex=2"
+    );
+    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
+    // andIHaveNoFurtherUses();
 
-    givenIHaveEnteredMyPersonalDetails();
-    givenIHaveEnteredMyAddressDetails();
-    givenIHaveEnteredMyEmergencyContactDetails();
+    // givenIHaveEnteredMyPersonalDetails();
+    // givenIHaveEnteredMyAddressDetails();
+    // givenIHaveEnteredMyEmergencyContactDetails();
 
-    thenTheUrlShouldContain(CreateRegistrationPageURLs.checkYourAnswers);
-    iCanSeeMyBeaconDetails();
-    iCanSeeMyAdditionalBeaconInformation();
-    iCanSeeASectionHeadingThatContains("Main use");
-    iCanSeeMyLandUse();
-    iCanSeeASectionHeadingThatContains("Second use");
-    iCanSeeMyMaritimeUse(Purpose.PLEASURE);
-    iCanSeeMyAviationUse(Purpose.PLEASURE);
-    iCanSeeMyPersonalDetails();
-    iCanSeeMyAddressDetails();
-    iCanSeeMyEmergencyContactDetails();
-    iCanGoBackThroughTheFormInReverse();
+    // thenTheUrlShouldContain(CreateRegistrationPageURLs.checkYourAnswers);
+    // iCanSeeMyBeaconDetails();
+    // iCanSeeMyAdditionalBeaconInformation();
+    // iCanSeeASectionHeadingThatContains("Main use");
+    // iCanSeeMyLandUse();
+    // iCanSeeASectionHeadingThatContains("Second use");
+    // iCanSeeMyMaritimeUse(Purpose.PLEASURE);
+    // iCanSeeMyAviationUse(Purpose.PLEASURE);
+    // iCanSeeMyPersonalDetails();
+    // iCanSeeMyAddressDetails();
+    // iCanSeeMyEmergencyContactDetails();
+    // iCanGoBackThroughTheFormInReverse();
   });
 });
 

--- a/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
@@ -37,9 +37,11 @@ import {
 import {
   andIHaveAnotherUse,
   andIHaveNoFurtherUses,
-  iAmEditingTheCorrectUse,
+  iAmOnTheLandBranchForUseNumber,
+  iAmOnTheMaritimeOrAviationBranchForUseNumber,
   iCanEditMyEnvironment,
   iCanEditMyNUses,
+  whenIGoToEditTheUseNumber,
 } from "../../common/i-can-enter-use-information/generic.spec";
 import {
   givenIHaveEnteredMyLandUse,
@@ -84,20 +86,18 @@ describe("As a single beacon owner with many uses", () => {
     iCanSeeAPageHeadingThatContains("third use");
     givenIHaveEnteredMyAviationUse(Purpose.PLEASURE);
     iCanEditMyNUses(3);
-    iAmEditingTheCorrectUse(
-      `${CreateRegistrationPageURLs.environment}?useIndex=0`,
-      `${CreateRegistrationPageURLs.activity}?useIndex=0`
-    );
+
+    whenIGoToEditTheUseNumber(0);
+    iAmOnTheLandBranchForUseNumber(0);
+
     givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
-    iAmEditingTheCorrectUse(
-      `${CreateRegistrationPageURLs.environment}?useIndex=1`,
-      `${CreateRegistrationPageURLs.purpose}?useIndex=1`
-    );
+    whenIGoToEditTheUseNumber(1);
+    iAmOnTheMaritimeOrAviationBranchForUseNumber(1);
+
     givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
-    iAmEditingTheCorrectUse(
-      `${CreateRegistrationPageURLs.environment}?useIndex=2`,
-      `${CreateRegistrationPageURLs.purpose}?useIndex=2`
-    );
+    whenIGoToEditTheUseNumber(2);
+    iAmOnTheMaritimeOrAviationBranchForUseNumber(2);
+
     givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
     andIHaveNoFurtherUses();
 

--- a/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
+++ b/cypress/integration/single-beacon-owner/i-can-register-a-beacon-with-many-uses.spec.ts
@@ -10,11 +10,19 @@ import {
   givenIHaveEnteredMyBeaconDetails,
   iCanEditMyAdditionalBeaconInformation,
   iCanEditMyBeaconDetails,
+  iCanSeeMyAdditionalBeaconInformation,
+  iCanSeeMyBeaconDetails,
 } from "../../common/i-can-enter-beacon-information.spec";
 import {
+  givenIHaveEnteredMyAddressDetails,
+  givenIHaveEnteredMyEmergencyContactDetails,
+  givenIHaveEnteredMyPersonalDetails,
   iCanEditMyAddressDetails,
   iCanEditMyEmergencyContactDetails,
   iCanEditMyPersonalDetails,
+  iCanSeeMyAddressDetails,
+  iCanSeeMyEmergencyContactDetails,
+  iCanSeeMyPersonalDetails,
 } from "../../common/i-can-enter-owner-information.spec";
 import {
   givenIHaveEnteredMyAviationUse,
@@ -24,9 +32,11 @@ import {
   iCanEditMyAviationActivity,
   iCanEditMyAviationEnvironment,
   iCanEditMyAviationPurpose,
+  iCanSeeMyAviationUse,
 } from "../../common/i-can-enter-use-information/aviation.spec";
 import {
   andIHaveAnotherUse,
+  andIHaveNoFurtherUses,
   iAmEditingTheCorrectUse,
   iCanEditMyEnvironment,
   iCanEditMyNUses,
@@ -37,6 +47,7 @@ import {
   iCanEditMyLandActivity,
   iCanEditMyLandCommunications,
   iCanEditMyLandEnvironment,
+  iCanSeeMyLandUse,
 } from "../../common/i-can-enter-use-information/land.spec";
 import {
   givenIHaveEnteredMyMaritimeUse,
@@ -46,12 +57,15 @@ import {
   iCanEditMyMaritimePurpose,
   iCanEditMyVesselCommunications,
   iCanEditMyVesselDetails,
+  iCanSeeMyMaritimeUse,
 } from "../../common/i-can-enter-use-information/maritime.spec";
 import {
   givenIHaveSignedIn,
   givenIHaveVisited,
   iCanSeeAPageHeadingThatContains,
+  iCanSeeASectionHeadingThatContains,
   iHaveVisited,
+  thenTheUrlShouldContain,
   whenIClickBack,
 } from "../../common/selectors-and-assertions.spec";
 
@@ -71,38 +85,38 @@ describe("As a single beacon owner with many uses", () => {
     givenIHaveEnteredMyAviationUse(Purpose.PLEASURE);
     iCanEditMyNUses(3);
     iAmEditingTheCorrectUse(
-      "/register-a-beacon/beacon-use?useIndex=0",
-      "/register-a-beacon/activity?useIndex=0"
+      `${CreateRegistrationPageURLs.environment}?useIndex=0`,
+      `${CreateRegistrationPageURLs.activity}?useIndex=0`
     );
-    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
+    givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
     iAmEditingTheCorrectUse(
-      "/register-a-beacon/beacon-use?useIndex=1",
-      "/register-a-beacon/purpose?useIndex=1"
+      `${CreateRegistrationPageURLs.environment}?useIndex=1`,
+      `${CreateRegistrationPageURLs.purpose}?useIndex=1`
     );
-    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
+    givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
     iAmEditingTheCorrectUse(
-      "/register-a-beacon/beacon-use?useIndex=2",
-      "/register-a-beacon/purpose?useIndex=2"
+      `${CreateRegistrationPageURLs.environment}?useIndex=2`,
+      `${CreateRegistrationPageURLs.purpose}?useIndex=2`
     );
-    givenIHaveVisited("/register-a-beacon/additional-beacon-use");
-    // andIHaveNoFurtherUses();
+    givenIHaveVisited(CreateRegistrationPageURLs.additionalUse);
+    andIHaveNoFurtherUses();
 
-    // givenIHaveEnteredMyPersonalDetails();
-    // givenIHaveEnteredMyAddressDetails();
-    // givenIHaveEnteredMyEmergencyContactDetails();
+    givenIHaveEnteredMyPersonalDetails();
+    givenIHaveEnteredMyAddressDetails();
+    givenIHaveEnteredMyEmergencyContactDetails();
 
-    // thenTheUrlShouldContain(CreateRegistrationPageURLs.checkYourAnswers);
-    // iCanSeeMyBeaconDetails();
-    // iCanSeeMyAdditionalBeaconInformation();
-    // iCanSeeASectionHeadingThatContains("Main use");
-    // iCanSeeMyLandUse();
-    // iCanSeeASectionHeadingThatContains("Second use");
-    // iCanSeeMyMaritimeUse(Purpose.PLEASURE);
-    // iCanSeeMyAviationUse(Purpose.PLEASURE);
-    // iCanSeeMyPersonalDetails();
-    // iCanSeeMyAddressDetails();
-    // iCanSeeMyEmergencyContactDetails();
-    // iCanGoBackThroughTheFormInReverse();
+    thenTheUrlShouldContain(CreateRegistrationPageURLs.checkYourAnswers);
+    iCanSeeMyBeaconDetails();
+    iCanSeeMyAdditionalBeaconInformation();
+    iCanSeeASectionHeadingThatContains("Main use");
+    iCanSeeMyLandUse();
+    iCanSeeASectionHeadingThatContains("Second use");
+    iCanSeeMyMaritimeUse(Purpose.PLEASURE);
+    iCanSeeMyAviationUse(Purpose.PLEASURE);
+    iCanSeeMyPersonalDetails();
+    iCanSeeMyAddressDetails();
+    iCanSeeMyEmergencyContactDetails();
+    iCanGoBackThroughTheFormInReverse();
   });
 });
 

--- a/src/lib/nextPageWithUseIndexHelper.ts
+++ b/src/lib/nextPageWithUseIndexHelper.ts
@@ -1,0 +1,5 @@
+import { queryParams } from "./urls";
+
+export const nextPageWithUseIndex = (useIndex: number, url: string): string => {
+  return url + queryParams({ useIndex });
+};

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -232,7 +232,10 @@ const BeaconPosition: FunctionComponent<FormInputProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.aircraftCommunications;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.aircraftCommunications +
+      queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/about-the-aircraft.tsx
+++ b/src/pages/register-a-beacon/about-the-aircraft.tsx
@@ -17,6 +17,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
@@ -232,11 +233,6 @@ const BeaconPosition: FunctionComponent<FormInputProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.aircraftCommunications +
-      queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingADraftRegistration_WhenNoDraftRegistrationExists_ThenRedirectUserToStartPage(
@@ -261,7 +257,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.aircraftCommunications
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -13,6 +13,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
@@ -246,11 +247,6 @@ const BeaconLocationInput: FunctionComponent<FormInputProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.vesselCommunications +
-      queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -275,7 +271,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.vesselCommunications
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/about-the-vessel.tsx
+++ b/src/pages/register-a-beacon/about-the-vessel.tsx
@@ -246,7 +246,10 @@ const BeaconLocationInput: FunctionComponent<FormInputProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.vesselCommunications;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.vesselCommunications +
+      queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -571,6 +571,7 @@ const LandOptions: FunctionComponent<OptionsProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
+    const useIndex = parseInt(context.query.useIndex as string);
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -595,7 +596,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        await nextPage(context)
+        (await nextPage(context)) + queryParams({ useIndex })
       ),
     ]).execute();
   })
@@ -630,7 +631,6 @@ const props = async (
       context.req.cookies[formSubmissionCookieId]
     )
   ).uses[context.query.useIndex as string];
-
   return {
     environment: (use?.environment as Environment) || null,
     purpose: (use?.purpose as Purpose) || null,

--- a/src/pages/register-a-beacon/activity.tsx
+++ b/src/pages/register-a-beacon/activity.tsx
@@ -21,6 +21,7 @@ import { DraftRegistrationPageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import { formSubmissionCookieId } from "../../lib/types";
 import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
@@ -571,7 +572,6 @@ const LandOptions: FunctionComponent<OptionsProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -596,7 +596,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        (await nextPage(context)) + queryParams({ useIndex })
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          await nextPage(context)
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/aircraft-communications.tsx
+++ b/src/pages/register-a-beacon/aircraft-communications.tsx
@@ -155,7 +155,9 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.moreDetails;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/aircraft-communications.tsx
+++ b/src/pages/register-a-beacon/aircraft-communications.tsx
@@ -16,6 +16,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { DraftRegistrationFormMapper } from "../../presenters/DraftRegistrationFormMapper";
@@ -155,10 +156,6 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -183,7 +180,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.moreDetails
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/beacon-use.tsx
+++ b/src/pages/register-a-beacon/beacon-use.tsx
@@ -15,7 +15,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
-import { CreateRegistrationPageURLs } from "../../lib/urls";
+import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { ordinal } from "../../lib/writingStyle";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
@@ -113,6 +113,7 @@ const BeaconUse: FunctionComponent<DraftBeaconUsePageProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
+    const useIndex = parseInt(context.query.useIndex as string);
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -137,7 +138,7 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        await nextPage(context)
+        (await nextPage(context)) + queryParams({ useIndex })
       ),
     ]).execute();
   })
@@ -154,7 +155,6 @@ const nextPage = async (
 ): Promise<CreateRegistrationPageURLs> => {
   const { environment } =
     await context.container.parseFormDataAs<BeaconUseForm>(context.req);
-
   return environment === Environment.LAND
     ? CreateRegistrationPageURLs.activity
     : CreateRegistrationPageURLs.purpose;

--- a/src/pages/register-a-beacon/beacon-use.tsx
+++ b/src/pages/register-a-beacon/beacon-use.tsx
@@ -15,7 +15,8 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
-import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
+import { CreateRegistrationPageURLs } from "../../lib/urls";
 import { ordinal } from "../../lib/writingStyle";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
 import { makeDraftRegistrationMapper } from "../../presenters/makeDraftRegistrationMapper";
@@ -113,7 +114,6 @@ const BeaconUse: FunctionComponent<DraftBeaconUsePageProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -138,7 +138,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        (await nextPage(context)) + queryParams({ useIndex })
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          await nextPage(context)
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/land-communications.tsx
+++ b/src/pages/register-a-beacon/land-communications.tsx
@@ -16,6 +16,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import {
   CreateRegistrationPageURLs,
   ofcomLicenseUrl,
@@ -182,10 +183,6 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -210,7 +207,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.moreDetails
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/land-communications.tsx
+++ b/src/pages/register-a-beacon/land-communications.tsx
@@ -182,7 +182,9 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.moreDetails;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/more-details.tsx
+++ b/src/pages/register-a-beacon/more-details.tsx
@@ -115,7 +115,9 @@ const MoreDetailsTextArea: FunctionComponent<MoreDetailsTextAreaProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.additionalUse;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.additionalUse + queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/more-details.tsx
+++ b/src/pages/register-a-beacon/more-details.tsx
@@ -14,6 +14,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import { formSubmissionCookieId } from "../../lib/types";
 import { CreateRegistrationPageURLs, queryParams } from "../../lib/urls";
 import { BeaconUseFormMapper } from "../../presenters/BeaconUseFormMapper";
@@ -115,10 +116,6 @@ const MoreDetailsTextArea: FunctionComponent<MoreDetailsTextAreaProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.additionalUse + queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -143,7 +140,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.additionalUse
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/purpose.tsx
+++ b/src/pages/register-a-beacon/purpose.tsx
@@ -84,7 +84,9 @@ const PurposePage: FunctionComponent<PurposeFormProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.activity;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.activity + queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -16,6 +16,7 @@ import { DraftBeaconUsePageProps } from "../../lib/handlePageRequest";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { withContainer } from "../../lib/middleware/withContainer";
 import { withSession } from "../../lib/middleware/withSession";
+import { nextPageWithUseIndex } from "../../lib/nextPageWithUseIndexHelper";
 import {
   CreateRegistrationPageURLs,
   ofcomLicenseUrl,
@@ -231,10 +232,6 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const useIndex = parseInt(context.query.useIndex as string);
-    const nextPage =
-      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
-
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),
       new GivenUserIsEditingAUse_IfNoUseIsSpecified_ThenSendUserToHighestUseIndexOrCreateNewUse(
@@ -259,7 +256,10 @@ export const getServerSideProps: GetServerSideProps = withContainer(
         context,
         validationRules,
         mapper(context),
-        nextPage
+        nextPageWithUseIndex(
+          parseInt(context.query.useIndex as string),
+          CreateRegistrationPageURLs.moreDetails
+        )
       ),
     ]).execute();
   })

--- a/src/pages/register-a-beacon/vessel-communications.tsx
+++ b/src/pages/register-a-beacon/vessel-communications.tsx
@@ -231,7 +231,9 @@ const TypesOfCommunication: FunctionComponent<{ form: FormJSON }> = ({
 
 export const getServerSideProps: GetServerSideProps = withContainer(
   withSession(async (context: BeaconsGetServerSidePropsContext) => {
-    const nextPage = CreateRegistrationPageURLs.moreDetails;
+    const useIndex = parseInt(context.query.useIndex as string);
+    const nextPage =
+      CreateRegistrationPageURLs.moreDetails + queryParams({ useIndex });
 
     return await new BeaconsPageRouter([
       new WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError(context),

--- a/test/lib/nextPageWithUseIndexHelper.test.ts
+++ b/test/lib/nextPageWithUseIndexHelper.test.ts
@@ -1,0 +1,9 @@
+import { nextPageWithUseIndex } from "../../src/lib/nextPageWithUseIndexHelper";
+
+describe("nextPageWithUseIndexHelper function", () => {
+  it("returns a URL with a useIndex parameter", () => {
+    expect(nextPageWithUseIndex(1, "/lorem/ipsum")).toBe(
+      "/lorem/ipsum?useIndex=1"
+    );
+  });
+});


### PR DESCRIPTION
## Context

Problem: editing draft beacon usages takes you to last created beacon use rather than chosen use to edit.
 `context` was taking `useIndex` from `uses.length - 1 `

## Changes in this pull request

Solution: append `useIndex` as query param to `nextPage` function on each page relevant to beacon use

## Guidance to review

- Register a beacon with multiple uses
- Click the change button on the additional beacon use page
- Click past the environment page
- Ensure the `useIndex` is correct in URL and the correct page is shown accordingly

## Link to Trello card

https://trello.com/c/oihRNUbC/1044-updating-a-use-when-you-have-multiple-jumps-to-updating-the-last-use