### PR TITLE
Cypress awaits expensive operations

### DIFF
--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -201,7 +201,7 @@ export const givenIHaveWaitedForAzureB2C = (): void => {
  */
 export const iPerformOperationAndWaitForPageToReload = (
   operation: () => void,
-  maxTimeoutMs = 10000
+  maxTimeoutMs = 20000
 ): void => {
   cy.window().then((w) => (w["initial"] = true));
   operation();

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -191,6 +191,14 @@ export const givenIHaveWaitedForBeaconsApi = (ms = 10000): void => {
   cy.wait(ms);
 };
 
+export const iPerformOperationAndWaitForThePageToReload = (
+  operation: () => void
+): void => {
+  cy.window().then((w) => (w["initial"] = true));
+  operation();
+  cy.window().its("initial").should("be.undefined");
+};
+
 export const andIHaveEnteredNoInformation = (): void => null;
 
 export const whenIClickBack = (): void => {

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -187,10 +187,6 @@ export const givenIHaveWaitedForAzureB2C = (): void => {
   cy.wait(1000);
 };
 
-export const givenIHaveWaitedForBeaconsApi = (ms = 10000): void => {
-  cy.wait(ms);
-};
-
 export const iPerformOperationAndWaitForThePageToReload = (
   operation: () => void
 ): void => {

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -187,12 +187,24 @@ export const givenIHaveWaitedForAzureB2C = (): void => {
   cy.wait(1000);
 };
 
-export const iPerformOperationAndWaitForThePageToReload = (
-  operation: () => void
+/**
+ *
+ * Performs an operation and ensures a new page has loaded before continuing.
+ *
+ * Will continue as soon as either:
+ *  - A new page is loaded
+ *  - @param maxTimeoutMs has elapsed
+ *
+ * @param operation - A callback function to perform
+ * @param maxTimeoutMs - Max time to wait in ms
+ */
+export const iPerformOperationAndWaitForPageToReload = (
+  operation: () => void,
+  maxTimeoutMs = 10000
 ): void => {
   cy.window().then((w) => (w["initial"] = true));
   operation();
-  cy.window().its("initial").should("be.undefined");
+  cy.window().its("initial", { timeout: maxTimeoutMs }).should("be.undefined");
 };
 
 export const andIHaveEnteredNoInformation = (): void => null;

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -199,13 +199,17 @@ export const givenIHaveWaitedForAzureB2C = (): void => {
  * @param operation - A callback function to perform
  * @param maxTimeoutMs - Max time to wait in ms
  */
-export const iPerformOperationAndWaitForPageToReload = (
+export const iPerformOperationAndWaitForNewPageToLoad = (
   operation: () => void,
   maxTimeoutMs = 20000
 ): void => {
-  cy.window().then((w) => (w["initial"] = true));
-  operation();
-  cy.window().its("initial", { timeout: maxTimeoutMs }).should("be.undefined");
+  cy.location().then((previousPage) => {
+    operation();
+    cy.location("pathname", { timeout: maxTimeoutMs }).should(
+      "not.equal",
+      previousPage.pathname
+    );
+  });
 };
 
 export const andIHaveEnteredNoInformation = (): void => null;

--- a/cypress/common/selectors-and-assertions.spec.ts
+++ b/cypress/common/selectors-and-assertions.spec.ts
@@ -191,9 +191,10 @@ export const givenIHaveWaitedForAzureB2C = (): void => {
  *
  * Performs an operation and ensures a new page has loaded before continuing.
  *
- * Will continue as soon as either:
- *  - A new page is loaded
- *  - @param maxTimeoutMs has elapsed
+ * Will continue as soon as a new page is loaded, up to the maximum timout
+ * set in @param maxTimeoutMs.
+ *
+ * Will fail if maxTimeoutMs is exceeded.
  *
  * @param operation - A callback function to perform
  * @param maxTimeoutMs - Max time to wait in ms

--- a/cypress/endToEnd/end-to-end.spec.ts
+++ b/cypress/endToEnd/end-to-end.spec.ts
@@ -23,7 +23,7 @@ import {
   givenIHaveACookieSetAndHaveSignedInIVisit,
   givenIHaveClicked,
   givenIHaveClickedTheButtonContaining,
-  iPerformOperationAndWaitForThePageToReload,
+  iPerformOperationAndWaitForPageToReload,
   thenTheUrlShouldContain,
 } from "../common/selectors-and-assertions.spec";
 
@@ -52,7 +52,7 @@ describe("As user with an account", () => {
     givenIHaveEnteredMyPersonalDetails();
     givenIHaveEnteredMyAddressDetails();
     givenIHaveEnteredMyEmergencyContactDetails();
-    iPerformOperationAndWaitForThePageToReload(() =>
+    iPerformOperationAndWaitForPageToReload(() =>
       givenIHaveClickedTheButtonContaining("Accept and send")
     );
     thenTheUrlShouldContain(CreateRegistrationPageURLs.applicationComplete);

--- a/cypress/endToEnd/end-to-end.spec.ts
+++ b/cypress/endToEnd/end-to-end.spec.ts
@@ -22,7 +22,8 @@ import { givenIHaveEnteredMyLandUse } from "../common/i-can-enter-use-informatio
 import {
   givenIHaveACookieSetAndHaveSignedInIVisit,
   givenIHaveClicked,
-  givenIHaveWaitedForBeaconsApi,
+  givenIHaveClickedTheButtonContaining,
+  iPerformOperationAndWaitForThePageToReload,
   thenTheUrlShouldContain,
 } from "../common/selectors-and-assertions.spec";
 
@@ -51,8 +52,9 @@ describe("As user with an account", () => {
     givenIHaveEnteredMyPersonalDetails();
     givenIHaveEnteredMyAddressDetails();
     givenIHaveEnteredMyEmergencyContactDetails();
-    givenIHaveClicked(".govuk-button--start");
-    givenIHaveWaitedForBeaconsApi();
+    iPerformOperationAndWaitForThePageToReload(() =>
+      givenIHaveClickedTheButtonContaining("Accept and send")
+    );
     thenTheUrlShouldContain(CreateRegistrationPageURLs.applicationComplete);
     givenIHaveClickedToGoBackToMyAccount();
     thenTheUrlShouldContain(AccountPageURLs.accountHome);

--- a/cypress/endToEnd/end-to-end.spec.ts
+++ b/cypress/endToEnd/end-to-end.spec.ts
@@ -23,7 +23,7 @@ import {
   givenIHaveACookieSetAndHaveSignedInIVisit,
   givenIHaveClicked,
   givenIHaveClickedTheButtonContaining,
-  iPerformOperationAndWaitForPageToReload,
+  iPerformOperationAndWaitForNewPageToLoad,
   thenTheUrlShouldContain,
 } from "../common/selectors-and-assertions.spec";
 
@@ -52,7 +52,7 @@ describe("As user with an account", () => {
     givenIHaveEnteredMyPersonalDetails();
     givenIHaveEnteredMyAddressDetails();
     givenIHaveEnteredMyEmergencyContactDetails();
-    iPerformOperationAndWaitForPageToReload(() =>
+    iPerformOperationAndWaitForNewPageToLoad(() =>
       givenIHaveClickedTheButtonContaining("Accept and send")
     );
     thenTheUrlShouldContain(CreateRegistrationPageURLs.applicationComplete);

--- a/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
+++ b/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
@@ -11,7 +11,7 @@ import {
   givenIHaveACookieSetAndHaveSignedIn,
   iCanSeeAButtonContaining,
   iHaveVisited,
-  iPerformOperationAndWaitForThePageToReload,
+  iPerformOperationAndWaitForPageToReload,
   thenIShouldSeeFormErrors,
   whenIClickTheButtonContaining,
   whenIHaveVisited,
@@ -55,7 +55,7 @@ describe("As an account holder", () => {
     thenIShouldSeeFormErrors("Enter a reason for deleting your registration");
 
     whenIEnterMyReasonInTheResultingTextbox("Lost overboard");
-    iPerformOperationAndWaitForThePageToReload(() =>
+    iPerformOperationAndWaitForPageToReload(() =>
       andIClickTheButtonContaining("Delete")
     );
     iAmGivenAConfirmationMessage();

--- a/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
+++ b/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
@@ -11,7 +11,7 @@ import {
   givenIHaveACookieSetAndHaveSignedIn,
   iCanSeeAButtonContaining,
   iHaveVisited,
-  iPerformOperationAndWaitForPageToReload,
+  iPerformOperationAndWaitForNewPageToLoad,
   thenIShouldSeeFormErrors,
   whenIClickTheButtonContaining,
   whenIHaveVisited,
@@ -55,7 +55,7 @@ describe("As an account holder", () => {
     thenIShouldSeeFormErrors("Enter a reason for deleting your registration");
 
     whenIEnterMyReasonInTheResultingTextbox("Lost overboard");
-    iPerformOperationAndWaitForPageToReload(() =>
+    iPerformOperationAndWaitForNewPageToLoad(() =>
       andIClickTheButtonContaining("Delete")
     );
     iAmGivenAConfirmationMessage();

--- a/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
+++ b/cypress/endToEnd/i-can-delete-a-beacon.spec.ts
@@ -11,6 +11,7 @@ import {
   givenIHaveACookieSetAndHaveSignedIn,
   iCanSeeAButtonContaining,
   iHaveVisited,
+  iPerformOperationAndWaitForThePageToReload,
   thenIShouldSeeFormErrors,
   whenIClickTheButtonContaining,
   whenIHaveVisited,
@@ -54,7 +55,9 @@ describe("As an account holder", () => {
     thenIShouldSeeFormErrors("Enter a reason for deleting your registration");
 
     whenIEnterMyReasonInTheResultingTextbox("Lost overboard");
-    andIClickTheButtonContaining("Delete");
+    iPerformOperationAndWaitForThePageToReload(() =>
+      andIClickTheButtonContaining("Delete")
+    );
     iAmGivenAConfirmationMessage();
 
     whenIGoBackToAccountHome();

--- a/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
@@ -37,8 +37,8 @@ import {
   andIClickContinue,
   givenIHaveSelected,
   givenIHaveSignedIn,
-  givenIHaveWaitedForBeaconsApi,
   iCanSeeAPageHeadingThatContains,
+  iPerformOperationAndWaitForThePageToReload,
   theBackLinkContains,
   thenTheUrlShouldContain,
   whenIClickBack,
@@ -96,8 +96,9 @@ describe("As an account holder", () => {
     iCanSeeMyUse(testRegistration.uses[0]);
     iCanSeeMyLandUse();
 
-    whenIClickTheButtonContaining("Accept and send");
-    givenIHaveWaitedForBeaconsApi(10000);
+    iPerformOperationAndWaitForThePageToReload(() =>
+      whenIClickTheButtonContaining("Accept and send")
+    );
     iCanSeeAPageHeadingThatContains(
       "Your beacon registration has been updated"
     );

--- a/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
@@ -38,7 +38,7 @@ import {
   givenIHaveSelected,
   givenIHaveSignedIn,
   iCanSeeAPageHeadingThatContains,
-  iPerformOperationAndWaitForThePageToReload,
+  iPerformOperationAndWaitForPageToReload,
   theBackLinkContains,
   thenTheUrlShouldContain,
   whenIClickBack,
@@ -96,7 +96,7 @@ describe("As an account holder", () => {
     iCanSeeMyUse(testRegistration.uses[0]);
     iCanSeeMyLandUse();
 
-    iPerformOperationAndWaitForThePageToReload(() =>
+    iPerformOperationAndWaitForPageToReload(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(

--- a/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration-with-many-uses.spec.ts
@@ -38,7 +38,7 @@ import {
   givenIHaveSelected,
   givenIHaveSignedIn,
   iCanSeeAPageHeadingThatContains,
-  iPerformOperationAndWaitForPageToReload,
+  iPerformOperationAndWaitForNewPageToLoad,
   theBackLinkContains,
   thenTheUrlShouldContain,
   whenIClickBack,
@@ -96,7 +96,7 @@ describe("As an account holder", () => {
     iCanSeeMyUse(testRegistration.uses[0]);
     iCanSeeMyLandUse();
 
-    iPerformOperationAndWaitForPageToReload(() =>
+    iPerformOperationAndWaitForNewPageToLoad(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(

--- a/cypress/endToEnd/i-can-update-a-registration.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration.spec.ts
@@ -22,7 +22,7 @@ import {
   givenIHaveSignedIn,
   iCanEditAFieldContaining,
   iCanSeeAPageHeadingThatContains,
-  iPerformOperationAndWaitForPageToReload,
+  iPerformOperationAndWaitForNewPageToLoad,
   theBackLinkContains,
   theBackLinkGoesTo,
   thenTheUrlShouldContain,
@@ -53,7 +53,7 @@ describe("As an account holder", () => {
     iCanUpdateTheDetailsOfMyExistingRegistration(firstRegistrationToUpdate);
     iCanSeeTheDetailsOfMyRegistration(firstUpdatedRegistration as Registration);
 
-    iPerformOperationAndWaitForPageToReload(() =>
+    iPerformOperationAndWaitForNewPageToLoad(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(
@@ -83,7 +83,7 @@ describe("As an account holder", () => {
     iCannotSeeAnAcceptAndSendButtonBecauseIHaveNotMadeAnyChanges();
     iCanUpdateTheDetailsOfMyExistingRegistration(secondRegistrationToUpdate);
 
-    iPerformOperationAndWaitForPageToReload(() =>
+    iPerformOperationAndWaitForNewPageToLoad(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(

--- a/cypress/endToEnd/i-can-update-a-registration.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration.spec.ts
@@ -20,9 +20,9 @@ import {
   andIClickContinue,
   andIClickTheButtonContaining,
   givenIHaveSignedIn,
-  givenIHaveWaitedForBeaconsApi,
   iCanEditAFieldContaining,
   iCanSeeAPageHeadingThatContains,
+  iPerformOperationAndWaitForThePageToReload,
   theBackLinkContains,
   theBackLinkGoesTo,
   thenTheUrlShouldContain,
@@ -53,8 +53,9 @@ describe("As an account holder", () => {
     iCanUpdateTheDetailsOfMyExistingRegistration(firstRegistrationToUpdate);
     iCanSeeTheDetailsOfMyRegistration(firstUpdatedRegistration as Registration);
 
-    whenIClickTheButtonContaining("Accept and send");
-    givenIHaveWaitedForBeaconsApi(10000);
+    iPerformOperationAndWaitForThePageToReload(() =>
+      whenIClickTheButtonContaining("Accept and send")
+    );
     iCanSeeAPageHeadingThatContains(
       "Your beacon registration has been updated"
     );
@@ -82,8 +83,9 @@ describe("As an account holder", () => {
     iCannotSeeAnAcceptAndSendButtonBecauseIHaveNotMadeAnyChanges();
     iCanUpdateTheDetailsOfMyExistingRegistration(secondRegistrationToUpdate);
 
-    whenIClickTheButtonContaining("Accept and send");
-    givenIHaveWaitedForBeaconsApi(10000);
+    iPerformOperationAndWaitForThePageToReload(() =>
+      whenIClickTheButtonContaining("Accept and send")
+    );
     iCanSeeAPageHeadingThatContains(
       "Your beacon registration has been updated"
     );

--- a/cypress/endToEnd/i-can-update-a-registration.spec.ts
+++ b/cypress/endToEnd/i-can-update-a-registration.spec.ts
@@ -22,7 +22,7 @@ import {
   givenIHaveSignedIn,
   iCanEditAFieldContaining,
   iCanSeeAPageHeadingThatContains,
-  iPerformOperationAndWaitForThePageToReload,
+  iPerformOperationAndWaitForPageToReload,
   theBackLinkContains,
   theBackLinkGoesTo,
   thenTheUrlShouldContain,
@@ -53,7 +53,7 @@ describe("As an account holder", () => {
     iCanUpdateTheDetailsOfMyExistingRegistration(firstRegistrationToUpdate);
     iCanSeeTheDetailsOfMyRegistration(firstUpdatedRegistration as Registration);
 
-    iPerformOperationAndWaitForThePageToReload(() =>
+    iPerformOperationAndWaitForPageToReload(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(
@@ -83,7 +83,7 @@ describe("As an account holder", () => {
     iCannotSeeAnAcceptAndSendButtonBecauseIHaveNotMadeAnyChanges();
     iCanUpdateTheDetailsOfMyExistingRegistration(secondRegistrationToUpdate);
 
-    iPerformOperationAndWaitForThePageToReload(() =>
+    iPerformOperationAndWaitForPageToReload(() =>
       whenIClickTheButtonContaining("Accept and send")
     );
     iCanSeeAPageHeadingThatContains(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Replace use of `cy.wait(<arbitrary time>)` in tests that perform expensive operations with a test that waits until the page has refreshed.

See https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/blogs__form-submit

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
