### PR TITLE
Add Logging To Webapp

### DIFF
--- a/logger/index.ts
+++ b/logger/index.ts
@@ -1,0 +1,12 @@
+import winston, { format } from "winston";
+
+const { combine, timestamp, errors, json } = format;
+
+const logger = winston.createLogger({
+  // formatting the log
+  format: combine(timestamp(), errors({ stack: true }), json()),
+  // locations to log to
+  transports: [new winston.transports.Console()],
+});
+
+export default logger;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react-dom": "17.0.2",
     "redis-json": "^6.0.1",
     "urlencoded-body-parser": "^3.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@jest/types": "^27.0.6",

--- a/src/gateways/AadAuthGateway.ts
+++ b/src/gateways/AadAuthGateway.ts
@@ -3,6 +3,7 @@ import {
   ConfidentialClientApplication,
   NodeAuthOptions,
 } from "@azure/msal-node";
+import logger from "../../logger";
 import { AuthGateway } from "./interfaces/AuthGateway";
 
 export class AadAuthGateway implements AuthGateway {
@@ -32,10 +33,11 @@ export class AadAuthGateway implements AuthGateway {
       const authResult = await cca.acquireTokenByClientCredential(
         accessTokenRequest
       );
+      logger.info("Access token retrieved");
       return authResult.accessToken;
     } catch (error) {
       /* eslint-disable no-console */
-      console.error(JSON.stringify(error));
+      logger.error("getAccessToken:", error);
       throw error;
     }
   }

--- a/src/gateways/BeaconsApiAccountHolderGateway.ts
+++ b/src/gateways/BeaconsApiAccountHolderGateway.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from "axios";
+import logger from "../../logger";
 import { AccountHolder } from "../entities/AccountHolder";
 import { Beacon } from "../entities/Beacon";
 import { AccountHolderGateway } from "./interfaces/AccountHolderGateway";
@@ -29,13 +30,14 @@ export class BeaconsApiAccountHolderGateway implements AccountHolderGateway {
       >(url, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Account holder id retrieved");
       return response.data.id;
     } catch (error) {
       if (error.response && error.response.status === 404) {
         return null; // 404 is a-ok
       }
       /* eslint-disable no-console */
-      console.error("getAccountHolderId:", JSON.stringify(error));
+      logger.error("getAccountHolderId:", error);
       throw error;
     }
   }
@@ -55,13 +57,14 @@ export class BeaconsApiAccountHolderGateway implements AccountHolderGateway {
       >(url, request, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Account holder created");
       return {
         id: response.data.data.id,
         ...response.data.data.attributes,
       };
     } catch (error) {
       /* eslint-disable no-console */
-      console.error("createAccountHolderId:", JSON.stringify(error));
+      logger.error("createAccountHolderId:", error);
       throw error;
     }
   }
@@ -77,13 +80,14 @@ export class BeaconsApiAccountHolderGateway implements AccountHolderGateway {
       >(url, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Account holder details retrieved");
       return {
         id: response.data.data.id,
         ...response.data.data.attributes,
       };
     } catch (error) {
       /* eslint-disable no-console */
-      console.error("getAccountHolderDetails:", error);
+      logger.error("getAccountHolderDetails:", error);
       throw error;
     }
   }
@@ -106,13 +110,14 @@ export class BeaconsApiAccountHolderGateway implements AccountHolderGateway {
       >(url, request, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Account holder details updated");
       return {
         id: response.data.data.id,
         ...response.data.data.attributes,
       };
     } catch (error) {
       /* eslint-disable no-console */
-      console.error("updateAccountHolderDetails:", JSON.stringify(error));
+      logger.error("updateAccountHolderDetails:", error);
       throw error;
     }
   }
@@ -126,11 +131,11 @@ export class BeaconsApiAccountHolderGateway implements AccountHolderGateway {
           headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
         }
       );
-
+      logger.info("Account beacons retrieved");
       return new BeaconsApiResponseMapper().mapList(response.data);
     } catch (error) {
       /* eslint-disable no-console */
-      console.error("getAccountBeacons:", error);
+      logger.error("getAccountBeacons:", error);
       throw error;
     }
   }

--- a/src/gateways/BeaconsApiBeaconGateway.ts
+++ b/src/gateways/BeaconsApiBeaconGateway.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import logger from "../../logger";
 import { DraftRegistration } from "../entities/DraftRegistration";
 import { Registration } from "../entities/Registration";
 import { DeprecatedRegistration } from "../lib/deprecatedRegistration/DeprecatedRegistration";
@@ -35,8 +36,10 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
       await axios.post(url, requestBody, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Registration sent");
       return true;
     } catch (error) {
+      logger.error("sendRegistration:", error);
       return false;
     }
   }
@@ -56,8 +59,10 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
       await axios.patch(url, requestBody, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Registration updated");
       return true;
     } catch (error) {
+      logger.error("updateRegistration:", error);
       return false;
     }
   }
@@ -74,8 +79,10 @@ export class BeaconsApiBeaconGateway implements BeaconGateway {
       await axios.patch(url, data, {
         headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
       });
+      logger.info("Beacon deleted");
       return true;
     } catch (error) {
+      logger.error("deleteBeacon:", error);
       return false;
     }
   }

--- a/src/gateways/BeaconsApiBeaconSearchGateway.ts
+++ b/src/gateways/BeaconsApiBeaconSearchGateway.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import logger from "../../logger";
 import { AuthGateway } from "./interfaces/AuthGateway";
 import {
   BeaconSearchGateway,
@@ -40,11 +41,11 @@ export class BeaconsApiBeaconSearchGateway implements BeaconSearchGateway {
           sort,
         },
       });
-
+      logger.info("Beacons retrieved by account holder id & email address");
       return response.data._embedded.beaconSearch;
     } catch (error) {
       /* eslint-disable no-console */
-      console.error("getBeaconsForAccountHolder", error);
+      logger.error("getBeaconsForAccountHolder:", error);
       throw error;
     }
   }

--- a/src/gateways/GovNotifyEmailServiceGateway.ts
+++ b/src/gateways/GovNotifyEmailServiceGateway.ts
@@ -1,4 +1,5 @@
 import { NotifyClient } from "notifications-node-client";
+import logger from "../../logger";
 import { EmailServiceGateway } from "./interfaces/EmailServiceGateway";
 
 export class GovNotifyEmailServiceGateway implements EmailServiceGateway {
@@ -6,7 +7,7 @@ export class GovNotifyEmailServiceGateway implements EmailServiceGateway {
   constructor(apiKey: string) {
     if (!apiKey) {
       // eslint-disable-next-line no-console
-      console.log(
+      logger.info(
         "GOV_NOTIFY_API_KEY not set on instantiation of GovNotifyEmailServiceGateway.  I'm not going to send any Gov Notify emails."
       );
     } else {
@@ -31,7 +32,7 @@ export class GovNotifyEmailServiceGateway implements EmailServiceGateway {
         })
         .catch((err) => {
           // eslint-disable-next-line no-console
-          console.error(err);
+          logger.error("sendEmail:", err);
         });
     } catch (error) {
       return false;

--- a/src/gateways/LegacyBeaconGateway.ts
+++ b/src/gateways/LegacyBeaconGateway.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import logger from "../../logger";
 import { LegacyBeaconGateway } from "./interfaces/LegacyBeaconGateway";
 
 export class BeaconsApiLegacyBeaconGateway implements LegacyBeaconGateway {
@@ -13,8 +14,10 @@ export class BeaconsApiLegacyBeaconGateway implements LegacyBeaconGateway {
     try {
       const url = `${this.apiUrl}/${this.legacyBeaconEndpoint}/${legacyBeaconId}`;
       const response = await axios.get(url);
+      logger.info("Legacy beacon retrieved");
       return response.data;
     } catch (error) {
+      logger.error("getLegacyBeacon:", error);
       return error;
     }
   }


### PR DESCRIPTION
## Context

Developers maintaining the live beacons webapp would benefit from events tracing. Logging is a way to trace events, so this PR involves console logging API call responses (successes & errors).

## Link to Trello card

https://trello.com/c/qQrGYrFg/1047-add-logging-to-the-web-application-so-information-is-viewable-in-cloudwatch

## Things to check

- [ ] Logs are displayed in the console
- [ ] Logs are in JSON format
- [ ] Logs all have a timestamp
- [ ] Logs all have a message/title
- [ ] Logs all indicate their severity (e.g. "level": "info")
- [ ] Error logs include a stack trace
- [ ] Logs are viewable in CloudWatch
