### PR TITLE
Hide reject option on claim page

### DIFF
--- a/cypress/endToEnd/i-can-claim-a-legacy-beacon.spec.ts
+++ b/cypress/endToEnd/i-can-claim-a-legacy-beacon.spec.ts
@@ -178,5 +178,6 @@ const whenIClickOnTheHexIdOfTheLegacyBeaconAssignedToMe = (hexId: string) => {
 const iAmGivenTheOptionToClaimOrRejectTheLegacyBeacon = () => {
   iCanSeeAPageHeadingThatContains("Is this beacon yours?");
   iCanSeeText(/this is my beacon/i);
-  iCanSeeText(/this is not my beacon/i);
+  // TODO: Implement reject flow
+  // iCanSeeText(/this is not my beacon/i);
 };

--- a/src/pages/manage-my-registrations/claim-legacy-beacon/[id].tsx
+++ b/src/pages/manage-my-registrations/claim-legacy-beacon/[id].tsx
@@ -79,7 +79,7 @@ const ClaimLegacyBeacon: FunctionComponent<ClaimLegacyBeaconPageProps> = ({
         {pageText}
         <FormGroup errorMessages={form.fields.claimResponse.errorMessages}>
           <div id="sign-in-hint" className="govuk-hint">
-            Please select one of the following options
+            Please confirm that this is your beacon.
           </div>
           <RadioList>
             <RadioListItem
@@ -89,13 +89,13 @@ const ClaimLegacyBeacon: FunctionComponent<ClaimLegacyBeaconPageProps> = ({
               hintText="By confirming this beacon is yours, you will be able to manage this beacon online. You will also need to provide additional information, which is vital to Search and Rescue should the beacon be activated."
               value="claim"
             />
-            <RadioListItem
-              id="reject"
-              name={fieldName}
-              label="This is not my beacon"
-              hintText="We may have matched this beacon to you because it was previously registered to the same email address. This beacon will be removed from your account and you will no longer see it when you log in."
-              value="reject"
-            />
+            {/*<RadioListItem*/}
+            {/*  id="reject"*/}
+            {/*  name={fieldName}*/}
+            {/*  label="This is not my beacon"*/}
+            {/*  hintText="We may have matched this beacon to you because it was previously registered to the same email address. This beacon will be removed from your account and you will no longer see it when you log in."*/}
+            {/*  value="reject"*/}
+            {/*/>*/}
           </RadioList>
         </FormGroup>
         <h2 className="govuk-heading-m">


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

Disable option for user to select `reject`.  The user either claims or goes back to Account Home.

![image](https://user-images.githubusercontent.com/54271433/135280398-784aed39-4237-4830-9d2a-59c0d608901a.png)

Necessary because `reject` is not yet implemented, and selecting the option currently results in a 500 error.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
