### PR TITLE
Remove account holder registrations from cache when going to update flow

### DIFF
--- a/src/router/rules/GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage.ts
+++ b/src/router/rules/GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage.ts
@@ -3,6 +3,7 @@ import { clearFormSubmissionCookie } from "../../lib/middleware";
 import { BeaconsGetServerSidePropsContext } from "../../lib/middleware/BeaconsGetServerSidePropsContext";
 import { redirectUserTo } from "../../lib/redirectUserTo";
 import { formSubmissionCookieId } from "../../lib/types";
+import { deleteCachedRegistrationsForAccountHolder } from "../../useCases/deleteCachedRegistrationsForAccountHolder";
 import { Rule } from "./Rule";
 
 export class GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage
@@ -21,8 +22,22 @@ export class GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItA
   }
 
   public async action(): Promise<GetServerSidePropsResult<any>> {
+    const {
+      getAccountHolderId,
+      draftRegistrationGateway,
+      accountHolderGateway,
+    } = this.context.container;
+
+    const accountHolderId = await getAccountHolderId(this.context.session);
+
     await this.context.container.deleteDraftRegistration(
       this.context.req.cookies[formSubmissionCookieId]
+    );
+
+    await deleteCachedRegistrationsForAccountHolder(
+      draftRegistrationGateway,
+      accountHolderGateway,
+      accountHolderId
     );
 
     clearFormSubmissionCookie(this.context);

--- a/src/useCases/deleteCachedRegistrationsForAccountHolder.ts
+++ b/src/useCases/deleteCachedRegistrationsForAccountHolder.ts
@@ -1,0 +1,14 @@
+import { AccountHolderGateway } from "../gateways/interfaces/AccountHolderGateway";
+import { DraftRegistrationGateway } from "../gateways/interfaces/DraftRegistrationGateway";
+
+export const deleteCachedRegistrationsForAccountHolder = async (
+  draftRegistrationGateway: DraftRegistrationGateway,
+  accountHolderGateway: AccountHolderGateway,
+  accountHolderId: string
+): Promise<void> => {
+  const beacons = await accountHolderGateway.getAccountBeacons(accountHolderId);
+
+  await Promise.all(
+    beacons.map((beacon) => draftRegistrationGateway.delete(beacon.id))
+  );
+};

--- a/test/router/rules/GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage.test.ts
+++ b/test/router/rules/GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage.test.ts
@@ -3,6 +3,8 @@ import { BeaconsGetServerSidePropsContext } from "../../../src/lib/middleware/Be
 import { formSubmissionCookieId } from "../../../src/lib/types";
 import { GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage } from "../../../src/router/rules/GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage";
 
+jest.mock("../../../src/useCases/deleteCachedRegistrationsForAccountHolder");
+
 describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage", () => {
   describe("condition()", () => {
     it("doesn't trigger if there are no cookies", async () => {
@@ -13,7 +15,7 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
         query: {
           registrationId: "60bcc58b-88bb-4a51-9c55-5fa54b748806",
         },
-      };
+      } as any;
       const rule =
         new GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndReloadPage(
           context
@@ -53,6 +55,12 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
               "user-is-already-editing-this-draft-registration",
           },
         },
+        container: {
+          getAccountHolderId: jest.fn(),
+          accountHolderGateway: {
+            getAccountBeacons: jest.fn(),
+          },
+        },
         query: {
           registrationId: "user-is-already-editing-this-draft-registration",
         },
@@ -77,6 +85,12 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
           query: {
             registrationId:
               "but-is-now-trying-to-do-something-to-a-different-draft-registration",
+          },
+          container: {
+            getAccountHolderId: jest.fn(),
+            accountHolderGateway: {
+              getAccountBeacons: jest.fn(),
+            },
           },
         },
       } as any;
@@ -103,6 +117,10 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
         },
         container: {
           deleteDraftRegistration: jest.fn(),
+          getAccountHolderId: jest.fn(),
+          accountHolderGateway: {
+            getAccountBeacons: jest.fn(),
+          },
         },
         res: {
           setHeader: jest.fn(),
@@ -131,6 +149,10 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
         },
         container: {
           deleteDraftRegistration: jest.fn(),
+          getAccountHolderId: jest.fn(),
+          accountHolderGateway: {
+            getAccountBeacons: jest.fn(),
+          },
         },
         res: {
           setHeader: jest.fn(),
@@ -161,6 +183,10 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
         },
         container: {
           deleteDraftRegistration: jest.fn(),
+          getAccountHolderId: jest.fn(),
+          accountHolderGateway: {
+            getAccountBeacons: jest.fn(),
+          },
         },
         res: {
           setHeader: jest.fn(),
@@ -171,7 +197,7 @@ describe("GivenUserHasStartedEditingADifferentDraftRegistration_ThenDeleteItAndR
           context
         );
 
-      const props = await rule.action();
+      const props = (await rule.action()) as any;
 
       expect(props.redirect.destination).toEqual("the-current-page");
     });


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
