### PR TITLE
Success failure ux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Bring up API and DB
         run: |
-          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose -f docker-compose.e2e.yml up --detach
+          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose --verbose -f docker-compose.e2e.yml up &
       - name: Copy env vars
         run: cp .env.example .env.local
       - name: Checkout node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Bring up API and DB
         run: |
-          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose -f docker-compose.e2e.yml --verbose up
+          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose -f docker-compose.e2e.yml up --detach
       - name: Copy env vars
         run: cp .env.example .env.local
       - name: Checkout node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Bring up API and DB
         run: |
-          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker-compose --file docker-compose.e2e.yml up --detach
+          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker-compose --file docker-compose.e2e.yml up --verbose
       - name: Copy env vars
         run: cp .env.example .env.local
       - name: Checkout node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Bring up API and DB
         run: |
-          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose --verbose -f docker-compose.e2e.yml up &
+          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose --verbose -f docker-compose.e2e.yml up --detach
       - name: Copy env vars
         run: cp .env.example .env.local
       - name: Checkout node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Bring up API and DB
         run: |
-          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker-compose --file docker-compose.e2e.yml up --verbose
+          SERVICE_COMMIT_HASH=${{ steps.get_service_commit_hash.outputs.service_commit_hash }} docker compose -f docker-compose.e2e.yml --verbose up
       - name: Copy env vars
         run: cp .env.example .env.local
       - name: Checkout node

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IntelliJ
 **/.idea/workspace.xml
 **/.idea/tasks.xml
+*.iml
 
 # MacOS
 **/.DS_Store

--- a/cypress/endToEnd/i-can-claim-a-legacy-beacon.spec.ts
+++ b/cypress/endToEnd/i-can-claim-a-legacy-beacon.spec.ts
@@ -122,7 +122,7 @@ describe("As an account holder", () => {
     iPerformOperationAndWaitForNewPageToLoad(() => {
       whenIClickTheButtonContaining("Accept and send");
     });
-    iCanSeeAPageHeadingThatContains("Beacon Registration Complete");
+    iCanSeeAPageHeadingThatContains("Beacon registration complete");
 
     whenIClickTheButtonContaining("Return to your Beacon Registry Account");
     thereIsOnlyOneBeaconListedForHexId(hexId);

--- a/cypress/integration/individual-pages/check-your-answers.spec.ts
+++ b/cypress/integration/individual-pages/check-your-answers.spec.ts
@@ -32,7 +32,7 @@ describe("As a beacon owner, I want to check the details that were submitted", (
     andIHaveVisited(CreateRegistrationPageURLs.checkYourAnswers);
     givenIHaveClicked(acceptAndSendButtonSelector);
     andIHaveVisited(CreateRegistrationPageURLs.applicationComplete);
-    cy.get("div").contains("There was an error while registering your beacon");
+    cy.get("div").contains(/We could not save your registration/i);
     givenIHaveClicked(homePageLinkSelector);
     andIHaveVisited(GeneralPageURLs.start);
     givenIHaveClicked(startButtonSelector);

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -26,8 +26,7 @@ services:
       retries: 12
 
   api:
-    image: beacons-service
-    #   image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
+    image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
       OPENSEARCH_URL: http://opensearch

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -14,6 +14,8 @@ services:
     image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
+      # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
+      SPRING_PROFILES_ACTIVE: "dev"
     ports:
       - 8080:8080
 
@@ -21,3 +23,14 @@ services:
     image: redis:6
     ports:
       - "6379:6379"
+
+  opensearch:
+    image: opensearchproject/opensearch:1.1.0
+    container_name: opensearch
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - ./opensearch.yml:/usr/share/opensearch/config/opensearch.yml
+    ports:
+      - "9200:9200"
+      - "9600:9600"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -20,6 +20,11 @@ services:
     ports:
       - "9200:9200"
       - "9600:9600"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   api:
     image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -18,8 +18,7 @@ services:
     volumes:
       - ./opensearch.yml:/usr/share/opensearch/config/opensearch.yml
     ports:
-      - "9200:9200"
-      - "9600:9600"
+      - 9200:9200
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s
@@ -27,9 +26,12 @@ services:
       retries: 12
 
   api:
-    image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
+    image: beacons-service
+    #   image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
+      OPENSEARCH_URL: http://opensearch
+      OPENSEARCH_PORT: 9200
       # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
       SPRING_PROFILES_ACTIVE: dev
     ports:
@@ -48,6 +50,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 12
+    restart: on-failure
 
   redis:
     image: redis:6

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -29,7 +29,7 @@ services:
     image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
-      OPENSEARCH_URL: http://opensearch
+      OPENSEARCH_URL: opensearch
       OPENSEARCH_PORT: 9200
       # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
       SPRING_PROFILES_ACTIVE: dev

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -21,10 +21,10 @@ services:
       - "9200:9200"
       - "9600:9600"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 10s
       timeout: 10s
-      retries: 5
+      retries: 12
 
   api:
     image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
@@ -37,6 +37,7 @@ services:
     depends_on:
       - opensearch
       - postgres
+    restart: on-failure
 
   redis:
     image: redis:6

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,20 +10,6 @@ services:
     ports:
       - 5432:5432
 
-  api:
-    image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
-      # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
-      SPRING_PROFILES_ACTIVE: "dev"
-    ports:
-      - 8080:8080
-
-  redis:
-    image: redis:6
-    ports:
-      - "6379:6379"
-
   opensearch:
     image: opensearchproject/opensearch:1.1.0
     container_name: opensearch
@@ -34,3 +20,20 @@ services:
     ports:
       - "9200:9200"
       - "9600:9600"
+
+  api:
+    image: 232705206979.dkr.ecr.eu-west-2.amazonaws.com/beacons-service:$SERVICE_COMMIT_HASH
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
+      # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
+      SPRING_PROFILES_ACTIVE: "dev"
+    ports:
+      - 8080:8080
+    depends_on:
+      - opensearch
+      - postgres
+
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -31,7 +31,7 @@ services:
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/beacons
       # 'dev' profile is necessary to allow Spring to connect to local OpenSearch container without authenticating
-      SPRING_PROFILES_ACTIVE: "dev"
+      SPRING_PROFILES_ACTIVE: dev
     ports:
       - 8080:8080
     depends_on:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -37,6 +37,17 @@ services:
     depends_on:
       - opensearch
       - postgres
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:8080/spring-api/actuator/health",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 12
 
   redis:
     image: redis:6

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -37,7 +37,6 @@ services:
     depends_on:
       - opensearch
       - postgres
-    restart: on-failure
 
   redis:
     image: redis:6

--- a/opensearch.yml
+++ b/opensearch.yml
@@ -1,0 +1,7 @@
+# Duplicated from https://github.com/mcagov/beacons-service/blob/main/opensearch.yml
+#
+# This duplication is entirely sub-optimal and should be removed by either refactoring to a modular monolith or
+# stubbing all services in the Webapp's test suite
+cluster.name: docker-cluster
+network.host: 0.0.0.0
+plugins.security.disabled: true

--- a/src/components/PanelFailed.tsx
+++ b/src/components/PanelFailed.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { ReactChild, ReactChildren } from "react";
 
-export const PanelFailed = () => (
+export const PanelFailed = (props: {
+  children: ReactChildren | ReactChild;
+}): JSX.Element => (
   <div
     className="govuk-error-summary"
     aria-labelledby="error-summary-title"
@@ -12,11 +14,7 @@ export const PanelFailed = () => (
     </h2>
     <div className="govuk-error-summary__body">
       <ul className="govuk-list govuk-error-summary__list">
-        <li>
-          {
-            "We could not save your registration. Please contact the Beacon Registry team using the details below."
-          }
-        </li>
+        <li>{props.children}</li>
       </ul>
     </div>
   </div>

--- a/src/components/PanelFailed.tsx
+++ b/src/components/PanelFailed.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export const PanelFailed = () => (
+  <div
+    className="govuk-error-summary"
+    aria-labelledby="error-summary-title"
+    role="alert"
+    data-module="govuk-error-summary"
+  >
+    <h2 className="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div className="govuk-error-summary__body">
+      <ul className="govuk-list govuk-error-summary__list">
+        <li>
+          {
+            "We could not save your registration. Please contact the Beacon Registry team using the details below."
+          }
+        </li>
+      </ul>
+    </div>
+  </div>
+);

--- a/src/components/PanelSucceeded.tsx
+++ b/src/components/PanelSucceeded.tsx
@@ -3,7 +3,7 @@ import { Panel } from "./Panel";
 
 export const PanelSucceeded = (props: {
   title: string;
-  children: ReactChild | ReactChildren;
+  children?: ReactChild | ReactChildren;
   reference?: string;
 }): JSX.Element => (
   <Panel title={props.title} reference={props.reference}>

--- a/src/components/PanelSucceeded.tsx
+++ b/src/components/PanelSucceeded.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Panel } from "./Panel";
+
+export const PanelSucceeded = (props: {
+  title: string;
+  reference: string;
+  confirmationEmailSuccess: boolean;
+}): JSX.Element => (
+  <Panel title={props.title} reference={props.reference}>
+    {props.confirmationEmailSuccess
+      ? "We have sent you a confirmation email."
+      : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
+  </Panel>
+);

--- a/src/components/PanelSucceeded.tsx
+++ b/src/components/PanelSucceeded.tsx
@@ -1,14 +1,12 @@
-import React from "react";
+import React, { ReactChild, ReactChildren } from "react";
 import { Panel } from "./Panel";
 
 export const PanelSucceeded = (props: {
   title: string;
-  reference: string;
-  confirmationEmailSuccess: boolean;
+  children: ReactChild | ReactChildren;
+  reference?: string;
 }): JSX.Element => (
   <Panel title={props.title} reference={props.reference}>
-    {props.confirmationEmailSuccess
-      ? "We have sent you a confirmation email."
-      : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
+    {props.children}
   </Panel>
 );

--- a/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -40,11 +40,9 @@ const ApplicationCompletePage = (props: {
               {props.updateSuccess ? (
                 <>
                   <PanelSucceeded
-                    title={pageHeading}
+                    title="Your beacon registration has been updated"
                     reference={props.reference}
-                  >
-                    Your beacon registration has been updated.
-                  </PanelSucceeded>
+                  />
                   <GovUKBody className="govuk-body">
                     Your updated details have been received by the Maritime and
                     Coastguard Beacon Registry team. You can now use your

--- a/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -23,7 +23,9 @@ const ApplicationCompletePage = (props: {
   reference: string;
   updateSuccess: boolean;
 }): JSX.Element => {
-  const pageHeading = props.updateSuccess ? "Update complete" : "Update failed";
+  const pageHeading = props.updateSuccess
+    ? "Update succeeded"
+    : "Update failed";
 
   return (
     <>
@@ -41,7 +43,7 @@ const ApplicationCompletePage = (props: {
                     title={pageHeading}
                     reference={props.reference}
                   >
-                    Your beacon has been updated.
+                    Your beacon registration has been updated.
                   </PanelSucceeded>
                   <GovUKBody className="govuk-body">
                     Your updated details have been received by the Maritime and

--- a/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -1,9 +1,12 @@
 import { GetServerSideProps } from "next";
-import React, { FunctionComponent } from "react";
+import React from "react";
 import { ReturnToYourAccountSection } from "../../../../components/domain/ReturnToYourAccountSection";
 import { Grid } from "../../../../components/Grid";
 import { Layout } from "../../../../components/Layout";
-import { Panel } from "../../../../components/Panel";
+import { BeaconRegistryContactInfo } from "../../../../components/Mca";
+import { PanelFailed } from "../../../../components/PanelFailed";
+import { PanelSucceeded } from "../../../../components/PanelSucceeded";
+import { GovUKBody } from "../../../../components/Typography";
 import { DraftRegistration } from "../../../../entities/DraftRegistration";
 import { verifyFormSubmissionCookieIsSet } from "../../../../lib/cookies";
 import { clearFormSubmissionCookie } from "../../../../lib/middleware";
@@ -13,18 +16,15 @@ import { withSession } from "../../../../lib/middleware/withSession";
 import { redirectUserTo } from "../../../../lib/redirectUserTo";
 import { formSubmissionCookieId } from "../../../../lib/types";
 import { GeneralPageURLs } from "../../../../lib/urls";
+import logger from "../../../../logger";
 import { WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError } from "../../../../router/rules/WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError";
-import { IUpdateRegistrationResult } from "../../../../useCases/updateRegistration";
 
-interface ApplicationCompleteProps {
+const ApplicationCompletePage = (props: {
   reference: string;
-  pageHeading: string;
-}
+  updateSuccess: boolean;
+}): JSX.Element => {
+  const pageHeading = props.updateSuccess ? "Update complete" : "Update failed";
 
-const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
-  reference,
-  pageHeading,
-}: ApplicationCompleteProps): JSX.Element => {
   return (
     <>
       <Layout
@@ -35,25 +35,36 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
         <Grid
           mainContent={
             <>
-              <Panel title={pageHeading} reference={reference} />
-              <ApplicationCompleteWhatNext />
+              {props.updateSuccess ? (
+                <>
+                  <PanelSucceeded
+                    title={pageHeading}
+                    reference={props.reference}
+                  >
+                    Your beacon has been updated.
+                  </PanelSucceeded>
+                  <GovUKBody className="govuk-body">
+                    Your updated details have been received by the Maritime and
+                    Coastguard Beacon Registry team. You can now use your
+                    beacon.
+                  </GovUKBody>
+                  <ReturnToYourAccountSection />
+                </>
+              ) : (
+                <>
+                  <PanelFailed>
+                    We could not update your beacon. Please contact the Beacon
+                    Registry team using the details below.
+                  </PanelFailed>
+                  <BeaconRegistryContactInfo />
+                </>
+              )}
+              <BeaconRegistryContactInfo />
               <ReturnToYourAccountSection />
             </>
           }
         />
       </Layout>
-    </>
-  );
-};
-
-const ApplicationCompleteWhatNext: FunctionComponent = (): JSX.Element => {
-  // TODO: Implement email confirmation of update
-  return (
-    <>
-      {/*<SectionHeading>What happens next</SectionHeading>*/}
-      {/*<GovUKBody>*/}
-      {/*  We have sent you an email confirming your registration has been updated*/}
-      {/*</GovUKBody>*/}
     </>
   );
 };
@@ -74,36 +85,37 @@ export const getServerSideProps: GetServerSideProps = withSession(
     if (!verifyFormSubmissionCookieIsSet(context))
       return redirectUserTo(GeneralPageURLs.start);
 
-    try {
-      const draftRegistration: DraftRegistration = await getDraftRegistration(
-        context.req.cookies[formSubmissionCookieId]
-      );
+    const draftRegistration: DraftRegistration = await getDraftRegistration(
+      context.req.cookies[formSubmissionCookieId]
+    );
 
+    try {
       const result = await updateRegistration(
         draftRegistration,
         draftRegistration.id
       );
 
-      const pageHeading = (result: IUpdateRegistrationResult) => {
-        if (result.beaconUpdated)
-          return "Your beacon registration has been updated.";
-        return "We could not update your registration. Please contact the Beacons Registry team.";
-      };
-
       clearFormSubmissionCookie(context);
+
+      if (!result.beaconUpdated) {
+        logger.error(
+          `Failed to update beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
+        );
+      }
 
       return {
         props: {
           reference: result.referenceNumber,
-          pageHeading: pageHeading(result),
+          updateSuccess: result.beaconUpdated,
         },
       };
-    } catch {
+    } catch (e) {
+      logger.error(
+        `Threw error ${e} when updating beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
+      );
       return {
         props: {
-          reference: "",
-          pageHeading:
-            "There was an error while updating your beacon.  Please contact the Beacons Registry team.",
+          updateSuccess: false,
         },
       };
     }

--- a/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
+++ b/src/pages/manage-my-registrations/[registrationId]/update/complete.tsx
@@ -48,7 +48,6 @@ const ApplicationCompletePage = (props: {
                     Coastguard Beacon Registry team. You can now use your
                     beacon.
                   </GovUKBody>
-                  <ReturnToYourAccountSection />
                 </>
               ) : (
                 <>

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -97,7 +97,7 @@ const ApplicationFailedMessage = () => (
       <ul className="govuk-list govuk-error-summary__list">
         <li>
           {
-            "We could not save your registration. Please contact the Beacons Registry team using the details below."
+            "We could not save your registration. Please contact the Beacon Registry team using the details below."
           }
         </li>
       </ul>

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -117,9 +117,9 @@ export const getServerSideProps: GetServerSideProps = withSession(
           confirmationEmailSuccess: result.confirmationEmailSent,
         },
       };
-    } catch {
+    } catch (e) {
       logger.error(
-        `Failed to register beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
+        `Threw error ${e} when registering beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
       );
       return {
         props: {

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -58,14 +58,12 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
                   </GovUKBody>
                 </>
               ) : (
-                <>
-                  <PanelFailed>
-                    We could not save your registration. Please contact the
-                    Beacon Registry team using the details below.
-                  </PanelFailed>
-                  <BeaconRegistryContactInfo />
-                </>
+                <PanelFailed>
+                  We could not save your registration. Please contact the Beacon
+                  Registry team using the details below.
+                </PanelFailed>
               )}
+              <BeaconRegistryContactInfo />
               <ReturnToYourAccountSection />
             </>
           }

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -46,11 +46,11 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
             <>
               {registrationSuccess ? (
                 <>
-                  <PanelSucceeded
-                    title={pageHeading}
-                    confirmationEmailSuccess={confirmationEmailSuccess}
-                    reference={reference}
-                  />
+                  <PanelSucceeded title={pageHeading} reference={reference}>
+                    {confirmationEmailSuccess
+                      ? "We have sent you a confirmation email."
+                      : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
+                  </PanelSucceeded>
                   <GovUKBody className="govuk-body">
                     Your application to register a UK 406 MHz beacon has been
                     received by the Maritime and Coastguard Beacon Registry
@@ -59,7 +59,10 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
                 </>
               ) : (
                 <>
-                  <PanelFailed />
+                  <PanelFailed>
+                    We could not save your registration. Please contact the
+                    Beacon Registry team using the details below.
+                  </PanelFailed>
                   <BeaconRegistryContactInfo />
                 </>
               )}

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -4,7 +4,8 @@ import { ReturnToYourAccountSection } from "../../components/domain/ReturnToYour
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { BeaconRegistryContactInfo } from "../../components/Mca";
-import { Panel } from "../../components/Panel";
+import { PanelFailed } from "../../components/PanelFailed";
+import { PanelSucceeded } from "../../components/PanelSucceeded";
 import { GovUKBody } from "../../components/Typography";
 import { DraftRegistration } from "../../entities/DraftRegistration";
 import { verifyFormSubmissionCookieIsSet } from "../../lib/cookies";
@@ -45,7 +46,7 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
             <>
               {registrationSuccess ? (
                 <>
-                  <ApplicationSuccessMessage
+                  <PanelSucceeded
                     title={pageHeading}
                     confirmationEmailSuccess={confirmationEmailSuccess}
                     reference={reference}
@@ -58,7 +59,7 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
                 </>
               ) : (
                 <>
-                  <ApplicationFailedMessage />
+                  <PanelFailed />
                   <BeaconRegistryContactInfo />
                 </>
               )}
@@ -70,40 +71,6 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
     </>
   );
 };
-
-const ApplicationSuccessMessage = (props: {
-  title: string;
-  reference: string;
-  confirmationEmailSuccess: boolean;
-}): JSX.Element => (
-  <Panel title={props.title} reference={props.reference}>
-    {props.confirmationEmailSuccess
-      ? "We have sent you a confirmation email."
-      : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
-  </Panel>
-);
-
-const ApplicationFailedMessage = () => (
-  <div
-    className="govuk-error-summary"
-    aria-labelledby="error-summary-title"
-    role="alert"
-    data-module="govuk-error-summary"
-  >
-    <h2 className="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
-    </h2>
-    <div className="govuk-error-summary__body">
-      <ul className="govuk-list govuk-error-summary__list">
-        <li>
-          {
-            "We could not save your registration. Please contact the Beacon Registry team using the details below."
-          }
-        </li>
-      </ul>
-    </div>
-  </div>
-);
 
 export const getServerSideProps: GetServerSideProps = withSession(
   withContainer(async (context: BeaconsGetServerSidePropsContext) => {

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from "next";
-import React, { FunctionComponent } from "react";
+import React from "react";
 import { ReturnToYourAccountSection } from "../../components/domain/ReturnToYourAccountSection";
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
@@ -19,18 +19,12 @@ import { GeneralPageURLs } from "../../lib/urls";
 import logger from "../../logger";
 import { WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError } from "../../router/rules/WhenUserIsNotSignedIn_ThenShowAnUnauthenticatedError";
 
-interface ApplicationCompleteProps {
+const ApplicationCompletePage = (props: {
   reference: string;
   registrationSuccess: boolean;
   confirmationEmailSuccess: boolean;
-}
-
-const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
-  reference,
-  registrationSuccess,
-  confirmationEmailSuccess,
-}: ApplicationCompleteProps): JSX.Element => {
-  const pageHeading = registrationSuccess
+}): JSX.Element => {
+  const pageHeading = props.registrationSuccess
     ? "Beacon registration complete"
     : "Beacon registration failed";
 
@@ -44,10 +38,13 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
         <Grid
           mainContent={
             <>
-              {registrationSuccess ? (
+              {props.registrationSuccess ? (
                 <>
-                  <PanelSucceeded title={pageHeading} reference={reference}>
-                    {confirmationEmailSuccess
+                  <PanelSucceeded
+                    title={pageHeading}
+                    reference={props.reference}
+                  >
+                    {props.confirmationEmailSuccess
                       ? "We have sent you a confirmation email."
                       : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
                   </PanelSucceeded>

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -136,7 +136,7 @@ export const getServerSideProps: GetServerSideProps = withSession(
 
       if (!result.beaconRegistered) {
         logger.error(
-          `Failed to register beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${formSubmissionCookieId}`
+          `Failed to register beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
         );
       }
 
@@ -149,7 +149,7 @@ export const getServerSideProps: GetServerSideProps = withSession(
       };
     } catch {
       logger.error(
-        `Failed to register beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${formSubmissionCookieId}`
+        `Failed to register beacon with hexId ${draftRegistration.hexId}. Check session cache for formSubmissionCookieId ${context.req.cookies[formSubmissionCookieId]}`
       );
       return {
         props: {

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -57,11 +57,10 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
                 </>
               ) : (
                 <>
-                  <ApplicationFailedMessage title={pageHeading} />
+                  <ApplicationFailedMessage />
                   <BeaconRegistryContactInfo />
                 </>
               )}
-
               <ReturnToYourAccountSection />
             </>
           }
@@ -79,16 +78,30 @@ const ApplicationSuccessMessage = (props: {
   <Panel title={props.title} reference={props.reference}>
     {props.confirmationEmailSuccess
       ? "We have sent you a confirmation email."
-      : "We could not send you a confirmation email. But we have registered your beacon under the following reference id."}
+      : "We could not send you a confirmation email but we have registered your beacon under the following reference id."}
   </Panel>
 );
 
-const ApplicationFailedMessage = (props: { title: string }) => (
-  <Panel title={props.title}>
-    {
-      "We could not save your registration or send you a confirmation email. Please contact the Beacons Registry team."
-    }
-  </Panel>
+const ApplicationFailedMessage = () => (
+  <div
+    className="govuk-error-summary"
+    aria-labelledby="error-summary-title"
+    role="alert"
+    data-module="govuk-error-summary"
+  >
+    <h2 className="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div className="govuk-error-summary__body">
+      <ul className="govuk-list govuk-error-summary__list">
+        <li>
+          {
+            "We could not save your registration. Please contact the Beacons Registry team using the details below."
+          }
+        </li>
+      </ul>
+    </div>
+  </div>
 );
 
 export const getServerSideProps: GetServerSideProps = withSession(

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -41,7 +41,6 @@ const ApplicationCompletePage: FunctionComponent<ApplicationCompleteProps> = ({
               <Panel title={pageHeading} reference={reference}>
                 {pageSubHeading}
               </Panel>
-              {/*<ApplicationCompleteWhatNext />*/}
               <GovUKBody className="govuk-body">
                 Your application to register a UK 406 MHz beacon has been
                 received by the Maritime and Coastguard Beacon Registry Team.

--- a/test/pages/register-a-beacon/application-complete.test.tsx
+++ b/test/pages/register-a-beacon/application-complete.test.tsx
@@ -16,7 +16,11 @@ import { ISubmitRegistrationResult } from "../../../src/useCases/submitRegistrat
 describe("ApplicationCompletePage", () => {
   it("should render correctly", () => {
     render(
-      <ApplicationCompletePage pageSubHeading={"Test"} reference={"Test"} />
+      <ApplicationCompletePage
+        registrationSuccess={true}
+        confirmationEmailSuccess={true}
+        reference="Test"
+      />
     );
   });
 
@@ -126,7 +130,7 @@ describe("ApplicationCompletePage", () => {
       expect(result["props"].reference).toBe("ABC123");
     });
 
-    it("should have a page heading on success", async () => {
+    it("When the registration succeeded, then the registrationSuccess boolean should be true", async () => {
       const successful: ISubmitRegistrationResult = {
         beaconRegistered: true,
         confirmationEmailSent: true,
@@ -142,10 +146,10 @@ describe("ApplicationCompletePage", () => {
 
       const result = await getServerSideProps(context as any);
 
-      expect(result["props"].pageSubHeading.length).toBeGreaterThan(1);
+      expect(result["props"].registrationSuccess).toBe(true);
     });
 
-    it("should have a page heading on failed confirmation email", async () => {
+    it("When the registration succeeded but the confirmation email failed to send, then the confirmationEmailSent boolean should be false", async () => {
       const failedEmail: ISubmitRegistrationResult = {
         beaconRegistered: true,
         confirmationEmailSent: false,
@@ -161,10 +165,10 @@ describe("ApplicationCompletePage", () => {
 
       const result = await getServerSideProps(context as any);
 
-      expect(result["props"].pageSubHeading.length).toBeGreaterThan(1);
+      expect(result["props"].confirmationEmailSuccess).toBe(false);
     });
 
-    it("should have a page heading on failed registration and failed confirmation email", async () => {
+    it("When both registration and confirmation email fail, then both confirmationEmailSuccess and registrationSuccess should be false", async () => {
       const failedEverything: ISubmitRegistrationResult = {
         beaconRegistered: false,
         confirmationEmailSent: false,
@@ -180,7 +184,8 @@ describe("ApplicationCompletePage", () => {
 
       const result = await getServerSideProps(context as any);
 
-      expect(result["props"].pageSubHeading.length).toBeGreaterThan(1);
+      expect(result["props"].registrationSuccess).toBe(false);
+      expect(result["props"].confirmationEmailSuccess).toBe(false);
     });
 
     it("should not throw if there is an error submitting the user's registration", async () => {
@@ -200,25 +205,6 @@ describe("ApplicationCompletePage", () => {
       const act = async () => await getServerSideProps(context as any);
 
       expect(act).not.toThrow();
-    });
-
-    it("should feedback to the user if there is an error submitting the user's registration", async () => {
-      const userRegistrationId = "user-form-submission-cookie-id";
-      const context = {
-        req: {
-          cookies: { [formSubmissionCookieId]: userRegistrationId },
-        },
-        res: createResponse(),
-        container: mockContainer,
-        session: { user: { authId: "a-session-id" } },
-      };
-      mockSubmitRegistration.mockImplementation(() => {
-        throw new Error();
-      });
-
-      const result = await getServerSideProps(context as any);
-
-      expect(result["props"].pageSubHeading).toMatch(/error/i);
     });
   });
 });

--- a/test/pages/register-a-beacon/application-complete.test.tsx
+++ b/test/pages/register-a-beacon/application-complete.test.tsx
@@ -108,7 +108,7 @@ describe("ApplicationCompletePage", () => {
 
       const result = await getServerSideProps(context as any);
 
-      expect(result["props"].reference).toBe("");
+      expect(result["props"].reference).toBeUndefined();
     });
 
     it("should return a reference number if creating the registration is successful", async () => {


### PR DESCRIPTION
Replace the green "success" panel with an error message when the registration fails:

![Screenshot 2022-02-10 at 16 50 05](https://user-images.githubusercontent.com/54271433/153456458-8fe7c1d1-ab93-4038-8f26-0e0340306d6c.png)

Also create a log entry flagging the failure and printing the session id so we can see what state the application was in when the error was created.

```
{"level":"error","message":"Failed to register beacon with hexId 1D0E9B07CEFFBFF. Check session cache for formSubmissionCookieId e04b7a6a-8f00-4267-8738-eaba95eaea6d","timestamp":"2022-02-10T16:51:33.109Z"}
```